### PR TITLE
feat: add new dark glass styles

### DIFF
--- a/CSS-GLASS-STYLES.html
+++ b/CSS-GLASS-STYLES.html
@@ -174,13 +174,18 @@ const CARDS=[];
 
 /* === 1 Soft === */
 CARDS.push({
-  id:'soft', title:'Soft Glass', key:'blur · saturate · base α',
+  id:'soft', title:'Soft Glass', key:'blur · saturate · base α · brightness',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.10)'; setBlurSat(p,6,110);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.10)'; p._more='brightness(1)';
+    setBlurSat(p,6,110,p._more);
     p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
     p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
   },
-  sliders:[ bgAlphaSlider(.10), ...baseBlurSat(6,110), borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22) ],
+  sliders:[
+    bgAlphaSlider(.10), ...baseBlurSat(6,110),
+    slider('Brightness %',70,140,1,100,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p,p._blur??6,p._sat??110,p._more); }),
+    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
+  ],
   buildCSS: buildSimpleCSS
 });
 
@@ -201,21 +206,43 @@ CARDS.push({
   buildCSS: buildSimpleCSS
 });
 
-/* === 3 Dimmed === */
+/* === 3 Moonlit Halo === */
 CARDS.push({
-  id:'dim', title:'Dimmed Glass', key:'blur + brightness↓',
+  id:'halo', title:'Moonlit Halo', key:'radial highlight',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.26)'; p._more='brightness(0.90)';
-    setBlurSat(p,14,115, p._more);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.18)'; setBlurSat(p,10,120);
+    const fx=el('div'); fx.className='halo'; p.appendChild(fx);
+    function paint(){
+      Object.assign(fx.style,{
+        position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
+        background:`radial-gradient(circle at ${p._x}% ${p._y}%, rgba(255,255,255,${p._a}), transparent ${p._r}%)`
+      });
+    }
+    p._x=30; p._y=20; p._r=60; p._a=.18; p._paint=paint; paint();
     p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
     p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
   },
   sliders:[
-    bgAlphaSlider(.26), ...baseBlurSat(14,115),
-    slider('Brightness %',60,120,1,90,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p, p._blur??14, p._sat??115, p._more); }),
+    bgAlphaSlider(.18), ...baseBlurSat(10,120),
+    slider('Halo α',0,.6,.01,.18,'',(p,v)=>{ p._a=v; p._paint(); }),
+    slider('Halo size %',20,100,1,60,'%',(p,v)=>{ p._r=v; p._paint(); }),
+    slider('Halo X %',0,100,1,30,'%',(p,v)=>{ p._x=v; p._paint(); }),
+    slider('Halo Y %',0,100,1,20,'%',(p,v)=>{ p._y=v; p._paint(); }),
     borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
   ],
-  buildCSS: buildSimpleCSS
+  buildCSS(p){
+    return buildOverlayCSS(p, 'after', (p) => {
+      const s = getComputedStyle(p.querySelector('.halo'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `background: ${s.background}`
+      ];
+    });
+  }
 });
 
 /* === 4 Acrylic === */
@@ -360,24 +387,42 @@ CARDS.push({
   buildCSS: buildSimpleCSS
 });
 
-/* === 9 Inset Bevel === */
+/* === 9 Liquid Outline === */
 CARDS.push({
-  id:'bevel', title:'Inset Bevel (4‑side)', key:'bevel px · light α · dark α',
+  id:'outline', title:'Liquid Outline', key:'soft dual glow',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.16)'; setBlurSat(p,12,118);
-    p._px=2; p._la=.35; p._da=.30;
-    p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`;
-    p._oblur=24; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.18; p.style.border='1px solid rgba(255,255,255,.18)';
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,14,120);
+    const fx=el('div'); fx.className='outlineFx'; p.appendChild(fx);
+    function paint(){
+      fx.style.position='absolute'; fx.style.inset='0'; fx.style.pointerEvents='none';
+      fx.style.borderRadius='inherit';
+      fx.style.boxShadow=`inset 0 0 0 ${p._inner}px rgba(255,255,255,${p._ia}), 0 0 ${p._outer}px rgba(0,150,255,${p._oa})`;
+    }
+    p._inner=1; p._ia=.25; p._outer=18; p._oa=.35; p._paint=paint; paint();
+    p._inset=''; p._oblur=20; p._oalpha=.22; rebuildShadow(p);
+    p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
   },
   sliders:[
-    bgAlphaSlider(.16), ...baseBlurSat(12,118),
-    slider('Bevel px',1,12,1,2,'px',(p,v)=>{ p._px=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Light α',.05,.8,.01,.35,'',(p,v)=>{ p._la=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Dark α',.05,.8,.01,.30,'',(p,v)=>{ p._da=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    ...outerShadowSliders(24,.22), borderWidthSlider(1), borderAlphaSlider(.18)
+    bgAlphaSlider(.14), ...baseBlurSat(14,120),
+    slider('Inner glow px',0,6,1,1,'px',(p,v)=>{ p._inner=v; p._paint(); }),
+    slider('Inner α',0,.8,.01,.25,'',(p,v)=>{ p._ia=v; p._paint(); }),
+    slider('Outer glow px',0,60,1,18,'px',(p,v)=>{ p._outer=v; p._paint(); }),
+    slider('Outer α',0,1,.01,.35,'',(p,v)=>{ p._oa=v; p._paint(); }),
+    ...outerShadowSliders(20,.22), borderWidthSlider(1), borderAlphaSlider(.14)
   ],
-  buildCSS: buildSimpleCSS
+  buildCSS(p){
+    return buildOverlayCSS(p, 'after', (p) => {
+      const s = getComputedStyle(p.querySelector('.outlineFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `box-shadow: ${s.boxShadow}`
+      ];
+    });
+  }
 });
 
 /* === 10 Double Glass === */
@@ -402,95 +447,84 @@ CARDS.push({
   buildCSS: buildSimpleCSS
 });
 
-/* === 11 Neon Gradient Border === */
+/* === 11 Aurora Ripple === */
 CARDS.push({
-  id:'neon', title:'Neon Gradient Border', key:'gradient rim + glow',
+  id:'aurora', title:'Aurora Ripple', key:'gradient waves',
   setup(p){
-    p._bgcol='13,14,35'; p.style.position='relative'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
-    p._bw=2; p._ba=0; p.style.border='2px solid transparent';
-    p._angle=135; p._glowBlur=14; p._glowA=.9;
-    p.style.backgroundImage='linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)';
-    p.style.backgroundOrigin='border-box'; p.style.backgroundClip='padding-box, border-box';
-    const glow=el('div'); glow.className='neonGlow'; Object.assign(glow.style,{
-      position:'absolute', inset:'-2px', borderRadius:'inherit', pointerEvents:'none',
-      background:'linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)', filter:'blur(14px)', opacity:'0.9',
-      WebkitMask:'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-      WebkitMaskComposite:'xor', maskComposite:'exclude', padding:'2px'
-    }); p.appendChild(glow);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
+    const fx=el('div'); fx.className='auroraFx'; p.appendChild(fx);
+    function paint(){
+      fx.style.position='absolute'; fx.style.inset='0'; fx.style.pointerEvents='none';
+      fx.style.borderRadius='inherit';
+      fx.style.background=`conic-gradient(from ${p._angle}deg at 50% 50%, rgba(0,255,255,.4), rgba(255,0,255,.4), rgba(0,255,255,.4))`;
+      fx.style.filter=`blur(${p._blurFx}px)`;
+      fx.style.opacity=p._op;
+    }
+    p._angle=45; p._blurFx=30; p._op=.5; p._paint=paint; paint();
+    p._inset=''; p._oblur=26; p._oalpha=.22; rebuildShadow(p);
+    p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
   },
   sliders:[
     bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Border width px',0,10,1,2,'px',(p,v)=>{ p._bw=v; p.style.borderWidth=v+'px'; const g=p.querySelector('.neonGlow'); g.style.inset = (-v)+'px'; g.style.padding = v+'px'; }),
-    slider('Glow blur px',0,60,1,14,'px',(p,v)=>{ p._glowBlur=v; p.querySelector('.neonGlow').style.filter=`blur(${v}px)`; }),
-    slider('Glow opacity',0,1,.01,.9,'',(p,v)=>{ p._glowA=v; p.querySelector('.neonGlow').style.opacity=String(v); }),
-    slider('Angle °',0,360,1,135,'deg',(p,v)=>{ p._angle=v; p.style.backgroundImage=`linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; p.querySelector('.neonGlow').style.background=`linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; })
+    slider('Wave blur px',0,80,1,30,'px',(p,v)=>{ p._blurFx=v; p._paint(); }),
+    slider('Wave opacity',0,1,.01,.5,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Angle °',0,360,1,45,'deg',(p,v)=>{ p._angle=v; p._paint(); }),
+    ...outerShadowSliders(26,.22), borderWidthSlider(1), borderAlphaSlider(.10)
   ],
   buildCSS(p){
-    const mainCss = [];
-    writeBaseCSS(p,mainCss);
-    mainCss.push(`background-image: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${p._angle}deg,#00ffd5,#7a5cff,#ff00e6);`);
-    mainCss.push(`background-origin: border-box;`);
-    mainCss.push(`background-clip: padding-box, border-box;`);
-
-    const s = getComputedStyle(p.querySelector('.neonGlow'));
-    const pseudoCss = [
-      'content: ""',
-      'position: absolute',
-      `inset: -${p._bw}px`,
-      'pointer-events: none',
-      'border-radius: inherit',
-      `padding: ${p._bw}px`,
-      `opacity: ${p._glowA}`,
-      `background: ${s.background}`,
-      `filter: blur(${p._glowBlur}px)`,
-      '-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-      '-webkit-mask-composite: xor',
-      'mask-composite: exclude'
-    ];
-
-    const finalCss = [
-      `.your-selector {`,
-      ...mainCss.map(line => `  ${line}`),
-      `}`,
-      ``,
-      `.your-selector::after {`,
-      ...pseudoCss.map(line => `  ${line}`),
-      `}`
-    ];
-    return finalCss.join('\n');
-  }
-});
-
-/* === 12 Duotone Prism Edge === */
-CARDS.push({
-  id:'duoprism', title:'Duotone Prism Edge', key:'two inner rims',
-  setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,125);
-    p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
-    p._oblur=26; p._oalpha=.20; rebuildShadow(p);
-    p._rimThk=2; p._cA=.55; p._mA=.55;
-    const rim=el('div'); rim.className='duoRim'; p.appendChild(rim);
-    function paint(){ rim.style.position='absolute'; rim.style.inset='0'; rim.style.pointerEvents='none'; rim.style.borderRadius='inherit';
-      rim.style.boxShadow=`inset 0 0 0 1px rgba(0,255,255,${p._cA}), inset 0 0 0 ${p._rimThk}px rgba(255,0,255,${p._mA})`; }
-    p._paintRim=paint; paint();
-  },
-  sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,125),
-    slider('Rim thickness px',1,10,1,2,'px',(p,v)=>{ p._rimThk=v; p._paintRim(); }),
-    slider('Cyan α',0,1,.01,.55,'',(p,v)=>{ p._cA=v; p._paintRim(); }),
-    slider('Magenta α',0,1,.01,.55,'',(p,v)=>{ p._mA=v; p._paintRim(); }),
-    ...outerShadowSliders(26,.20), borderWidthSlider(1), borderAlphaSlider(.10)
-  ],
-  buildCSS(p){
-    return buildOverlayCSS(p, 'after', (p) => {
-      const s = getComputedStyle(p.querySelector('.duoRim'));
+    return buildOverlayCSS(p,'after',(p)=>{
+      const s=getComputedStyle(p.querySelector('.auroraFx'));
       return [
         'content: ""',
         'position: absolute',
         'inset: 0',
         'pointer-events: none',
         'border-radius: inherit',
-        `box-shadow: ${s.boxShadow}`
+        `background: ${s.background}`,
+        `filter: ${s.filter}`,
+        `opacity: ${s.opacity}`
+      ];
+    });
+  }
+});
+
+/* === 12 Liquid Shimmer === */
+CARDS.push({
+  id:'shimmer', title:'Liquid Shimmer', key:'moving sheen',
+  setup(p){
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,10,120);
+    const fx=el('div'); fx.className='shimmerFx'; p.appendChild(fx);
+    function paint(){
+      fx.style.position='absolute'; fx.style.inset='0'; fx.style.pointerEvents='none';
+      fx.style.borderRadius='inherit';
+      fx.style.background=`linear-gradient(${p._angle}deg, rgba(255,255,255,${p._sheenA}) ${p._pos}%, transparent ${p._pos+20}%)`;
+      fx.style.opacity=p._op;
+      fx.style.mixBlendMode='overlay';
+    }
+    p._angle=60; p._pos=30; p._sheenA=.25; p._op=.4; p._paint=paint; paint();
+    p._inset=''; p._oblur=26; p._oalpha=.22; rebuildShadow(p);
+    p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
+  },
+  sliders:[
+    bgAlphaSlider(.14), ...baseBlurSat(10,120),
+    slider('Sheen α',0,.6,.01,.25,'',(p,v)=>{ p._sheenA=v; p._paint(); }),
+    slider('Sheen position %',0,100,1,30,'%',(p,v)=>{ p._pos=v; p._paint(); }),
+    slider('Angle °',0,360,1,60,'deg',(p,v)=>{ p._angle=v; p._paint(); }),
+    slider('Overlay opacity',0,1,.01,.4,'',(p,v)=>{ p._op=v; p._paint(); }),
+    ...outerShadowSliders(26,.22), borderWidthSlider(1), borderAlphaSlider(.10)
+  ],
+  buildCSS(p){
+    return buildOverlayCSS(p,'after',(p)=>{
+      const s=getComputedStyle(p.querySelector('.shimmerFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `background: ${s.background}`,
+        `opacity: ${s.opacity}`,
+        'mix-blend-mode: overlay'
       ];
     });
   }


### PR DESCRIPTION
## Summary
- add brightness slider to Soft Glass and update key
- replace Dimmed, Inset Bevel, Neon Gradient Border, and Duotone Prism Edge with new dark-mode styles: Moonlit Halo, Liquid Outline, Aurora Ripple, and Liquid Shimmer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf86755a44832eb09236a972df8fcd