### PR TITLE
Add new dark-mode glass styles and controls

### DIFF
--- a/CSS-GLASS-STYLES.html
+++ b/CSS-GLASS-STYLES.html
@@ -201,21 +201,39 @@ CARDS.push({
   buildCSS: buildSimpleCSS
 });
 
-/* === 3 Dimmed === */
+/* === 3 Liquid Dark === */
 CARDS.push({
-  id:'dim', title:'Dimmed Glass', key:'blur + brightness↓',
+  id:'liquid', title:'Liquid Dark', key:'radial highlight',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.26)'; p._more='brightness(0.90)';
-    setBlurSat(p,14,115, p._more);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.24)'; setBlurSat(p,16,135);
     p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
+    const fx=el('div'); fx.className='liquidFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
+      background:`radial-gradient(circle at ${p._hx}% ${p._hy}%, rgba(255,255,255,${p._ha}), rgba(255,255,255,0) ${p._hs}%)`
+    }); }
+    p._hx=30; p._hy=30; p._hs=60; p._ha=.25; p._paint=paint; paint();
   },
   sliders:[
-    bgAlphaSlider(.26), ...baseBlurSat(14,115),
-    slider('Brightness %',60,120,1,90,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p, p._blur??14, p._sat??115, p._more); }),
-    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
+    bgAlphaSlider(.24), ...baseBlurSat(16,135),
+    slider('Highlight α',0,.6,.01,.25,'',(p,v)=>{ p._ha=v; p._paint(); }),
+    slider('Highlight size %',10,100,1,60,'%',(p,v)=>{ p._hs=v; p._paint(); }),
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(28,.22)
   ],
-  buildCSS: buildSimpleCSS
+  buildCSS(p){
+    return buildOverlayCSS(p,'after',(p)=>{
+      const s = getComputedStyle(p.querySelector('.liquidFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `background: ${s.backgroundImage}`
+      ];
+    });
+  }
 });
 
 /* === 4 Acrylic === */
@@ -299,15 +317,17 @@ CARDS.push({
     const fx=el('div'); fx.className='glossFx'; p.appendChild(fx);
     function paint(){ Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
-      background:`linear-gradient(${p._sheenAngle}deg, rgba(255,255,255,${p._sheenA}), rgba(255,255,255,0) ${p._sheenStop}%)`
+      background:`linear-gradient(${p._sheenAngle}deg, rgba(255,255,255,${p._sheenA}), rgba(255,255,255,0) ${p._sheenStop}%)`,
+      filter:`blur(${p._sheenBlur}px)`
     }); }
-    p._sheenAngle=180; p._sheenStop=35; p._sheenA=.18; p._paint=paint; paint();
+    p._sheenAngle=180; p._sheenStop=35; p._sheenA=.18; p._sheenBlur=8; p._paint=paint; paint();
   },
   sliders:[
     bgAlphaSlider(.12), ...baseBlurSat(12,120),
     slider('Sheen α',0,.6,.01,.18,'',(p,v)=>{ p._sheenA=v; p._paint(); }),
     slider('Sheen stop %',10,80,1,35,'%',(p,v)=>{ p._sheenStop=v; p._paint(); }),
     slider('Sheen angle °',0,360,1,180,'deg',(p,v)=>{ p._sheenAngle=v; p._paint(); }),
+    slider('Sheen blur px',0,20,1,8,'px',(p,v)=>{ p._sheenBlur=v; p._paint(); }),
     borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(30,.22)
   ],
   buildCSS(p){
@@ -319,7 +339,8 @@ CARDS.push({
         'inset: 0',
         'pointer-events: none',
         'border-radius: inherit',
-        `background: ${s.backgroundImage || s.background}`
+        `background: ${s.backgroundImage || s.background}`,
+        `filter: ${s.filter}`
       ];
     });
   }
@@ -360,22 +381,22 @@ CARDS.push({
   buildCSS: buildSimpleCSS
 });
 
-/* === 9 Inset Bevel === */
+/* === 9 Edge Shine === */
 CARDS.push({
-  id:'bevel', title:'Inset Bevel (4‑side)', key:'bevel px · light α · dark α',
+  id:'edge', title:'Edge Shine', key:'inner glow + darken',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.16)'; setBlurSat(p,12,118);
-    p._px=2; p._la=.35; p._da=.30;
-    p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`;
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.18)'; setBlurSat(p,12,120);
+    p._gB=20; p._gA=.30; p._dA=.25;
+    p._inset = `inset 0 0 ${p._gB}px rgba(255,255,255,${p._gA}), inset 0 0 ${p._gB}px rgba(0,0,0,${p._dA})`;
     p._oblur=24; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.18; p.style.border='1px solid rgba(255,255,255,.18)';
+    p._bw=1; p._ba=.16; p.style.border='1px solid rgba(255,255,255,.16)';
   },
   sliders:[
-    bgAlphaSlider(.16), ...baseBlurSat(12,118),
-    slider('Bevel px',1,12,1,2,'px',(p,v)=>{ p._px=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Light α',.05,.8,.01,.35,'',(p,v)=>{ p._la=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Dark α',.05,.8,.01,.30,'',(p,v)=>{ p._da=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    ...outerShadowSliders(24,.22), borderWidthSlider(1), borderAlphaSlider(.18)
+    bgAlphaSlider(.18), ...baseBlurSat(12,120),
+    slider('Light glow α',0,.8,.01,.30,'',(p,v)=>{ p._gA=v; p._inset = `inset 0 0 ${p._gB}px rgba(255,255,255,${p._gA}), inset 0 0 ${p._gB}px rgba(0,0,0,${p._dA})`; rebuildShadow(p); }),
+    slider('Dark edge α',0,.8,.01,.25,'',(p,v)=>{ p._dA=v; p._inset = `inset 0 0 ${p._gB}px rgba(255,255,255,${p._gA}), inset 0 0 ${p._gB}px rgba(0,0,0,${p._dA})`; rebuildShadow(p); }),
+    slider('Glow blur px',0,40,1,20,'px',(p,v)=>{ p._gB=v; p._inset = `inset 0 0 ${p._gB}px rgba(255,255,255,${p._gA}), inset 0 0 ${p._gB}px rgba(0,0,0,${p._dA})`; rebuildShadow(p); }),
+    ...outerShadowSliders(24,.22), borderWidthSlider(1), borderAlphaSlider(.16)
   ],
   buildCSS: buildSimpleCSS
 });
@@ -402,95 +423,76 @@ CARDS.push({
   buildCSS: buildSimpleCSS
 });
 
-/* === 11 Neon Gradient Border === */
+/* === 11 Aurora Glow === */
 CARDS.push({
-  id:'neon', title:'Neon Gradient Border', key:'gradient rim + glow',
+  id:'aurora', title:'Aurora Glow', key:'blurred gradient wash',
   setup(p){
-    p._bgcol='13,14,35'; p.style.position='relative'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
-    p._bw=2; p._ba=0; p.style.border='2px solid transparent';
-    p._angle=135; p._glowBlur=14; p._glowA=.9;
-    p.style.backgroundImage='linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)';
-    p.style.backgroundOrigin='border-box'; p.style.backgroundClip='padding-box, border-box';
-    const glow=el('div'); glow.className='neonGlow'; Object.assign(glow.style,{
-      position:'absolute', inset:'-2px', borderRadius:'inherit', pointerEvents:'none',
-      background:'linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)', filter:'blur(14px)', opacity:'0.9',
-      WebkitMask:'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-      WebkitMaskComposite:'xor', maskComposite:'exclude', padding:'2px'
-    }); p.appendChild(glow);
-  },
-  sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Border width px',0,10,1,2,'px',(p,v)=>{ p._bw=v; p.style.borderWidth=v+'px'; const g=p.querySelector('.neonGlow'); g.style.inset = (-v)+'px'; g.style.padding = v+'px'; }),
-    slider('Glow blur px',0,60,1,14,'px',(p,v)=>{ p._glowBlur=v; p.querySelector('.neonGlow').style.filter=`blur(${v}px)`; }),
-    slider('Glow opacity',0,1,.01,.9,'',(p,v)=>{ p._glowA=v; p.querySelector('.neonGlow').style.opacity=String(v); }),
-    slider('Angle °',0,360,1,135,'deg',(p,v)=>{ p._angle=v; p.style.backgroundImage=`linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; p.querySelector('.neonGlow').style.background=`linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; })
-  ],
-  buildCSS(p){
-    const mainCss = [];
-    writeBaseCSS(p,mainCss);
-    mainCss.push(`background-image: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${p._angle}deg,#00ffd5,#7a5cff,#ff00e6);`);
-    mainCss.push(`background-origin: border-box;`);
-    mainCss.push(`background-clip: padding-box, border-box;`);
-
-    const s = getComputedStyle(p.querySelector('.neonGlow'));
-    const pseudoCss = [
-      'content: ""',
-      'position: absolute',
-      `inset: -${p._bw}px`,
-      'pointer-events: none',
-      'border-radius: inherit',
-      `padding: ${p._bw}px`,
-      `opacity: ${p._glowA}`,
-      `background: ${s.background}`,
-      `filter: blur(${p._glowBlur}px)`,
-      '-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-      '-webkit-mask-composite: xor',
-      'mask-composite: exclude'
-    ];
-
-    const finalCss = [
-      `.your-selector {`,
-      ...mainCss.map(line => `  ${line}`),
-      `}`,
-      ``,
-      `.your-selector::after {`,
-      ...pseudoCss.map(line => `  ${line}`),
-      `}`
-    ];
-    return finalCss.join('\n');
-  }
-});
-
-/* === 12 Duotone Prism Edge === */
-CARDS.push({
-  id:'duoprism', title:'Duotone Prism Edge', key:'two inner rims',
-  setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,125);
+    p._bgcol='13,14,35'; p.style.position='relative'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,125);
     p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
-    p._oblur=26; p._oalpha=.20; rebuildShadow(p);
-    p._rimThk=2; p._cA=.55; p._mA=.55;
-    const rim=el('div'); rim.className='duoRim'; p.appendChild(rim);
-    function paint(){ rim.style.position='absolute'; rim.style.inset='0'; rim.style.pointerEvents='none'; rim.style.borderRadius='inherit';
-      rim.style.boxShadow=`inset 0 0 0 1px rgba(0,255,255,${p._cA}), inset 0 0 0 ${p._rimThk}px rgba(255,0,255,${p._mA})`; }
-    p._paintRim=paint; paint();
+    const fx=el('div'); fx.className='auroraFx'; Object.assign(fx.style,{
+      position:'absolute', inset:'-40%', pointerEvents:'none', borderRadius:'inherit',
+      background:'conic-gradient(from 0deg at 50% 50%, #00ffff, #7a5cff, #ff007c, #00ffff)',
+      filter:'blur(40px)', opacity:'0.55'
+    }); p.appendChild(fx);
   },
   sliders:[
     bgAlphaSlider(.12), ...baseBlurSat(12,125),
-    slider('Rim thickness px',1,10,1,2,'px',(p,v)=>{ p._rimThk=v; p._paintRim(); }),
-    slider('Cyan α',0,1,.01,.55,'',(p,v)=>{ p._cA=v; p._paintRim(); }),
-    slider('Magenta α',0,1,.01,.55,'',(p,v)=>{ p._mA=v; p._paintRim(); }),
-    ...outerShadowSliders(26,.20), borderWidthSlider(1), borderAlphaSlider(.10)
+    slider('Glow blur px',10,80,1,40,'px',(p,v)=>{ p.querySelector('.auroraFx').style.filter=`blur(${v}px)`; }),
+    slider('Glow α',0,1,.01,.55,'',(p,v)=>{ p.querySelector('.auroraFx').style.opacity=String(v); }),
+    borderWidthSlider(1), borderAlphaSlider(.10), ...outerShadowSliders(28,.22)
   ],
   buildCSS(p){
-    return buildOverlayCSS(p, 'after', (p) => {
-      const s = getComputedStyle(p.querySelector('.duoRim'));
+    return buildOverlayCSS(p,'before',(p)=>{
+      const s = getComputedStyle(p.querySelector('.auroraFx'));
       return [
         'content: ""',
         'position: absolute',
-        'inset: 0',
+        'inset: -40%',
         'pointer-events: none',
         'border-radius: inherit',
-        `box-shadow: ${s.boxShadow}`
+        `opacity: ${s.opacity}`,
+        `background: ${s.backgroundImage || s.background}`,
+        `filter: ${s.filter}`
+      ];
+    });
+  }
+});
+
+/* === 12 Chromatic Border === */
+CARDS.push({
+  id:'chromatic', title:'Chromatic Border', key:'hue rotate gradient rim',
+  setup(p){
+    p._bgcol='13,14,35'; p.style.position='relative'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
+    p._bw=2; p._ba=0; p.style.border='2px solid transparent';
+    p._h=210; p._ang=45;
+    const rim=el('div'); rim.className='chromaRim'; Object.assign(rim.style,{
+      position:'absolute', inset:'-2px', borderRadius:'inherit', pointerEvents:'none',
+      background:`linear-gradient(${p._ang}deg, hsl(${p._h},100%,70%), hsl(${(p._h+120)%360},100%,70%), hsl(${(p._h+240)%360},100%,70%))`,
+      WebkitMask:'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+      WebkitMaskComposite:'xor', maskComposite:'exclude', padding:'2px'
+    }); p.appendChild(rim);
+  },
+  sliders:[
+    bgAlphaSlider(.12), ...baseBlurSat(12,120),
+    slider('Border width px',0,10,1,2,'px',(p,v)=>{ p._bw=v; p.style.borderWidth=v+'px'; const r=p.querySelector('.chromaRim'); r.style.inset=(-v)+'px'; r.style.padding=v+'px'; }),
+    slider('Hue',0,360,1,210,'deg',(p,v)=>{ p._h=v; const r=p.querySelector('.chromaRim'); r.style.background=`linear-gradient(${p._ang}deg, hsl(${p._h},100%,70%), hsl(${(p._h+120)%360},100%,70%), hsl(${(p._h+240)%360},100%,70%))`; }),
+    slider('Angle °',0,360,1,45,'deg',(p,v)=>{ p._ang=v; const r=p.querySelector('.chromaRim'); r.style.background=`linear-gradient(${v}deg, hsl(${p._h},100%,70%), hsl(${(p._h+120)%360},100%,70%), hsl(${(p._h+240)%360},100%,70%))`; }),
+    borderAlphaSlider(.0), ...outerShadowSliders(26,.22)
+  ],
+  buildCSS(p){
+    return buildOverlayCSS(p,'after',(p)=>{
+      const s = getComputedStyle(p.querySelector('.chromaRim'));
+      return [
+        'content: ""',
+        'position: absolute',
+        `inset: -${p._bw}px`,
+        'pointer-events: none',
+        'border-radius: inherit',
+        `padding: ${p._bw}px`,
+        `background: ${s.backgroundImage || s.background}`,
+        '-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+        '-webkit-mask-composite: xor',
+        'mask-composite: exclude'
       ];
     });
   }


### PR DESCRIPTION
## Summary
- replace Dimmed, Inset Bevel, Neon Gradient Border, and Duotone Prism Edge with fresh dark-mode liquid glass styles
- add iOS-inspired Aurora Glow and Liquid Dark panels with adjustable highlights
- provide Chromatic Border and Edge Shine effects with customizable color rims and inner glows
- enhance Glossy Highlight with a new blur slider and CSS output

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfadc68c58832e959dcdbd9c70ede2