### PR TITLE
feat: expand liquid glass style library

### DIFF
--- a/CSS-GLASS-STYLES.html
+++ b/CSS-GLASS-STYLES.html
@@ -172,15 +172,21 @@ function bgAlphaSlider(initA=0.12){
 
 const CARDS=[];
 
-/* === 1 Soft === */
+/* === 1 Midnight === */
 CARDS.push({
-  id:'soft', title:'Soft Glass', key:'blur · saturate · base α',
+  id:'midnight', title:'Midnight Glass', key:'dark tint · inner glow',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.10)'; setBlurSat(p,6,110);
-    p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.20)';
+    setBlurSat(p,14,125);
+    p._insetA=.08; p._inset=`inset 0 1px 1px rgba(255,255,255,${p._insetA})`;
+    p._oblur=30; p._oalpha=.30; rebuildShadow(p);
+    p._bw=1; p._ba=.18; p.style.border='1px solid rgba(255,255,255,.18)';
   },
-  sliders:[ bgAlphaSlider(.10), ...baseBlurSat(6,110), borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22) ],
+  sliders:[
+    bgAlphaSlider(.20), ...baseBlurSat(14,125),
+    slider('Inner light α',0,.3,.01,.08,'',(p,v)=>{ p._insetA=v; p._inset=`inset 0 1px 1px rgba(255,255,255,${p._insetA})`; rebuildShadow(p); }),
+    borderWidthSlider(1), borderAlphaSlider(.18), ...outerShadowSliders(30,.30)
+  ],
   buildCSS: buildSimpleCSS
 });
 
@@ -188,34 +194,54 @@ CARDS.push({
 CARDS.push({
   id:'bright', title:'Bright Glass', key:'blur + brightness↑',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; p._more='brightness(1.08)';
-    setBlurSat(p,12,125, p._more);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; p._more='brightness(1.10)';
+    setBlurSat(p,12,130, p._more);
     p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
     p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
   },
   sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,125),
-    slider('Brightness %',90,160,1,108,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p, p._blur??12, p._sat??125, p._more); }),
+    bgAlphaSlider(.12), ...baseBlurSat(12,130),
+    slider('Brightness %',90,160,1,110,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p, p._blur??12, p._sat??130, p._more); }),
     borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
   ],
   buildCSS: buildSimpleCSS
 });
 
-/* === 3 Dimmed === */
+/* === 3 Cursor Halo === */
 CARDS.push({
-  id:'dim', title:'Dimmed Glass', key:'blur + brightness↓',
+  id:'halo', title:'Cursor Halo', key:'radial glow',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.26)'; p._more='brightness(0.90)';
-    setBlurSat(p,14,115, p._more);
-    p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.18)'; setBlurSat(p,12,120);
+    p._oblur=28; p._oalpha=.24; rebuildShadow(p);
+    p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
+    const fx=el('div'); fx.className='haloFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
+      background:`radial-gradient(circle at ${p._cx}% ${p._cy}%, rgba(255,255,255,${p._ha}), transparent ${p._size}%)`
+    }); }
+    p._cx=50; p._cy=40; p._size=60; p._ha=.25; p._paint=paint; paint();
   },
   sliders:[
-    bgAlphaSlider(.26), ...baseBlurSat(14,115),
-    slider('Brightness %',60,120,1,90,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p, p._blur??14, p._sat??115, p._more); }),
-    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
+    bgAlphaSlider(.18), ...baseBlurSat(12,120),
+    slider('Halo α',0,.6,.01,.25,'',(p,v)=>{ p._ha=v; p._paint(); }),
+    slider('Halo size %',10,120,1,60,'%',(p,v)=>{ p._size=v; p._paint(); }),
+    slider('Center X %',0,100,1,50,'%',(p,v)=>{ p._cx=v; p._paint(); }),
+    slider('Center Y %',0,100,1,40,'%',(p,v)=>{ p._cy=v; p._paint(); }),
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(28,.24)
   ],
-  buildCSS: buildSimpleCSS
+  buildCSS(p){
+    return buildOverlayCSS(p,'after',(p)=>{
+      const s=getComputedStyle(p.querySelector('.haloFx'));
+      return[
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `background: ${s.backgroundImage || s.background}`
+      ];
+    });
+  }
 });
 
 /* === 4 Acrylic === */
@@ -227,14 +253,14 @@ CARDS.push({
     p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
     const fx=el('div'); fx.className='noise'; Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
-      backgroundImage:'radial-gradient(rgba(255,255,255,0.03) 1px, transparent 1px)',
-      backgroundSize:'2px 2px'
+      backgroundImage:'radial-gradient(rgba(255,255,255,0.04) 1px, transparent 1px)',
+      backgroundSize:'3px 3px'
     }); p.appendChild(fx);
   },
   sliders:[
     bgAlphaSlider(.06), ...baseBlurSat(8,130),
-    slider('Noise α',0,.12,.001,.03,'',(p,v)=>{ p.querySelector('.noise').style.backgroundImage=`radial-gradient(rgba(255,255,255,${v}) 1px, transparent 1px)`; }),
-    slider('Noise size px',1,8,1,2,'px',(p,v)=>{ p.querySelector('.noise').style.backgroundSize=`${v}px ${v}px`; }),
+    slider('Noise α',0,.12,.001,.04,'',(p,v)=>{ p.querySelector('.noise').style.backgroundImage=`radial-gradient(rgba(255,255,255,${v}) 1px, transparent 1px)`; }),
+    slider('Noise size px',1,8,1,3,'px',(p,v)=>{ p.querySelector('.noise').style.backgroundSize=`${v}px ${v}px`; }),
     borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(30,.22)
   ],
   buildCSS(p){
@@ -263,12 +289,12 @@ CARDS.push({
     const fx=el('div'); fx.className='paperFx'; Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
       backgroundImage:'radial-gradient(rgba(255,255,255,.03) 1px, transparent 1px), radial-gradient(rgba(0,0,0,.06) 1px, transparent 1px)',
-      backgroundSize:'1px 1px, 2px 2px',opacity:'0.7'
+      backgroundSize:'1px 1px, 2px 2px',opacity:'0.6'
     }); p.appendChild(fx);
   },
   sliders:[
     bgAlphaSlider(.10), ...baseBlurSat(10,120),
-    slider('Grain opacity',0,1,.01,.7,'',(p,v)=>{ p.querySelector('.paperFx').style.opacity=String(v); }),
+    slider('Grain opacity',0,1,.01,.6,'',(p,v)=>{ p.querySelector('.paperFx').style.opacity=String(v); }),
     slider('Grain size px',1,8,1,1,'px',(p,v)=>{ p.querySelector('.paperFx').style.backgroundSize=`${v}px ${v}px, ${v*2}px ${v*2}px`; }),
     borderWidthSlider(1), borderAlphaSlider(.10), ...outerShadowSliders(30,.20)
   ],
@@ -301,12 +327,12 @@ CARDS.push({
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
       background:`linear-gradient(${p._sheenAngle}deg, rgba(255,255,255,${p._sheenA}), rgba(255,255,255,0) ${p._sheenStop}%)`
     }); }
-    p._sheenAngle=180; p._sheenStop=35; p._sheenA=.18; p._paint=paint; paint();
+    p._sheenAngle=180; p._sheenStop=40; p._sheenA=.22; p._paint=paint; paint();
   },
   sliders:[
     bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Sheen α',0,.6,.01,.18,'',(p,v)=>{ p._sheenA=v; p._paint(); }),
-    slider('Sheen stop %',10,80,1,35,'%',(p,v)=>{ p._sheenStop=v; p._paint(); }),
+    slider('Sheen α',0,.6,.01,.22,'',(p,v)=>{ p._sheenA=v; p._paint(); }),
+    slider('Sheen stop %',10,80,1,40,'%',(p,v)=>{ p._sheenStop=v; p._paint(); }),
     slider('Sheen angle °',0,360,1,180,'deg',(p,v)=>{ p._sheenAngle=v; p._paint(); }),
     borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(30,.22)
   ],
@@ -325,57 +351,61 @@ CARDS.push({
   }
 });
 
-/* === 7 Tinted === */
+/* === 7 Crystal Tint === */
 CARDS.push({
-  id:'tint', title:'Tinted (HSLA)', key:'tint hue · alpha',
+  id:'crystal', title:'Crystal Tint', key:'dual hue gradient',
   setup(p){
-    p._h=270; p._tinta=.18;
-    p.style.backgroundColor=`hsla(${p._h},70%,45%,${p._tinta})`;
-    setBlurSat(p,12,120);
+    p._h1=200; p._h2=340; p._a=.25;
+    p.style.background=`linear-gradient(135deg, hsla(${p._h1},60%,50%,${p._a}), hsla(${p._h2},60%,50%,${p._a}))`;
+    setBlurSat(p,14,130);
     p._inset=''; p._oblur=30; p._oalpha=.22; rebuildShadow(p);
     p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
   },
   sliders:[
-    ...baseBlurSat(12,120),
-    slider('Tint hue °',0,360,1,270,'deg',(p,v)=>{ p._h=v; p.style.backgroundColor=`hsla(${p._h},70%,45%,${p._tinta})`; }),
-    slider('Tint α',0,.6,.01,.18,'',(p,v)=>{ p._tinta=v; p.style.backgroundColor=`hsla(${p._h},70%,45%,${p._tinta})`; }),
+    ...baseBlurSat(14,130),
+    slider('Hue A °',0,360,1,200,'deg',(p,v)=>{ p._h1=v; p.style.background=`linear-gradient(135deg, hsla(${p._h1},60%,50%,${p._a}), hsla(${p._h2},60%,50%,${p._a}))`; }),
+    slider('Hue B °',0,360,1,340,'deg',(p,v)=>{ p._h2=v; p.style.background=`linear-gradient(135deg, hsla(${p._h1},60%,50%,${p._a}), hsla(${p._h2},60%,50%,${p._a}))`; }),
+    slider('Tint α',0,.6,.01,.25,'',(p,v)=>{ p._a=v; p.style.background=`linear-gradient(135deg, hsla(${p._h1},60%,50%,${p._a}), hsla(${p._h2},60%,50%,${p._a}))`; }),
     borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(30,.22)
   ],
   buildCSS: buildSimpleCSS
 });
 
-/* === 8 Heavy Frost === */
+/* === 8 Frosted Edge === */
 CARDS.push({
-  id:'frost', title:'Heavy Frost', key:'white frost',
+  id:'frosted', title:'Frosted Edge', key:'white frost · edge glow',
   setup(p){
-    p._fA=.16; p.style.backgroundColor=`rgba(255,255,255,${p._fA})`; setBlurSat(p,14,120);
-    p._inset=''; p._oblur=32; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.22; p.style.border='1px solid rgba(255,255,255,.22)';
+    p._fA=.18; p._edgeA=.30;
+    p.style.backgroundColor=`rgba(255,255,255,${p._fA})`; setBlurSat(p,20,140);
+    p._inset=`inset 0 0 0 1px rgba(255,255,255,${p._edgeA})`;
+    p._oblur=32; p._oalpha=.25; rebuildShadow(p);
+    p._bw=1; p._ba=.40; p.style.border='1px solid rgba(255,255,255,.40)';
   },
   sliders:[
-    ...baseBlurSat(14,120),
-    slider('Frost α',0,.6,.01,.16,'',(p,v)=>{ p._fA=v; p.style.backgroundColor=`rgba(255,255,255,${p._fA})`; }),
-    borderWidthSlider(1), borderAlphaSlider(.22), ...outerShadowSliders(32,.22)
+    ...baseBlurSat(20,140),
+    slider('Frost α',0,.8,.01,.18,'',(p,v)=>{ p._fA=v; p.style.backgroundColor=`rgba(255,255,255,${p._fA})`; }),
+    slider('Edge α',0,.8,.01,.30,'',(p,v)=>{ p._edgeA=v; p._inset=`inset 0 0 0 1px rgba(255,255,255,${p._edgeA})`; rebuildShadow(p); }),
+    borderWidthSlider(1), borderAlphaSlider(.40), ...outerShadowSliders(32,.25)
   ],
   buildCSS: buildSimpleCSS
 });
 
-/* === 9 Inset Bevel === */
+/* === 9 Soft Bezel === */
 CARDS.push({
-  id:'bevel', title:'Inset Bevel (4‑side)', key:'bevel px · light α · dark α',
+  id:'bezelsoft', title:'Soft Bezel', key:'depth px · light α · dark α',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.16)'; setBlurSat(p,12,118);
-    p._px=2; p._la=.35; p._da=.30;
-    p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`;
-    p._oblur=24; p._oalpha=.22; rebuildShadow(p);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.18)'; setBlurSat(p,14,122);
+    p._depth=1; p._lightA=.40; p._darkA=.35;
+    p._inset=`inset 0 ${p._depth}px 1px rgba(255,255,255,${p._lightA}), inset 0 -${p._depth}px 1px rgba(0,0,0,${p._darkA})`;
+    p._oblur=24; p._oalpha=.24; rebuildShadow(p);
     p._bw=1; p._ba=.18; p.style.border='1px solid rgba(255,255,255,.18)';
   },
   sliders:[
-    bgAlphaSlider(.16), ...baseBlurSat(12,118),
-    slider('Bevel px',1,12,1,2,'px',(p,v)=>{ p._px=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Light α',.05,.8,.01,.35,'',(p,v)=>{ p._la=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Dark α',.05,.8,.01,.30,'',(p,v)=>{ p._da=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    ...outerShadowSliders(24,.22), borderWidthSlider(1), borderAlphaSlider(.18)
+    bgAlphaSlider(.18), ...baseBlurSat(14,122),
+    slider('Depth px',1,8,1,1,'px',(p,v)=>{ p._depth=v; p._inset=`inset 0 ${p._depth}px 1px rgba(255,255,255,${p._lightA}), inset 0 -${p._depth}px 1px rgba(0,0,0,${p._darkA})`; rebuildShadow(p); }),
+    slider('Light α',0,.8,.01,.40,'',(p,v)=>{ p._lightA=v; p._inset=`inset 0 ${p._depth}px 1px rgba(255,255,255,${p._lightA}), inset 0 -${p._depth}px 1px rgba(0,0,0,${p._darkA})`; rebuildShadow(p); }),
+    slider('Dark α',0,.8,.01,.35,'',(p,v)=>{ p._darkA=v; p._inset=`inset 0 ${p._depth}px 1px rgba(255,255,255,${p._lightA}), inset 0 -${p._depth}px 1px rgba(0,0,0,${p._darkA})`; rebuildShadow(p); }),
+    ...outerShadowSliders(24,.24), borderWidthSlider(1), borderAlphaSlider(.18)
   ],
   buildCSS: buildSimpleCSS
 });
@@ -385,7 +415,7 @@ CARDS.push({
   id:'double', title:'Double Glass', key:'outer rim · inner rim · alphas',
   setup(p){
     p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,12,120);
-    p._outerPx=12; p._innerPx=2; p._r1=.20; p._r2=.45;
+    p._outerPx=10; p._innerPx=2; p._r1=.18; p._r2=.40;
     p._rims = ()=> `inset 0 0 0 ${p._outerPx}px rgba(255,255,255,${p._r1}), inset 0 0 0 ${p._innerPx}px rgba(255,255,255,${p._r2})`;
     p._inset = p._rims();
     p._oblur=26; p._oalpha=.22; rebuildShadow(p);
@@ -393,46 +423,46 @@ CARDS.push({
   },
   sliders:[
     bgAlphaSlider(.14), ...baseBlurSat(12,120),
-    slider('Outer rim px',0,30,1,12,'px',(p,v)=>{ p._outerPx=v; p._inset = p._rims(); rebuildShadow(p); }),
-    slider('Outer α',0,.6,.01,.20,'',(p,v)=>{ p._r1=v; p._inset = p._rims(); rebuildShadow(p); }),
+    slider('Outer rim px',0,30,1,10,'px',(p,v)=>{ p._outerPx=v; p._inset = p._rims(); rebuildShadow(p); }),
+    slider('Outer α',0,.6,.01,.18,'',(p,v)=>{ p._r1=v; p._inset = p._rims(); rebuildShadow(p); }),
     slider('Inner rim px',0,12,1,2,'px',(p,v)=>{ p._innerPx=v; p._inset = p._rims(); rebuildShadow(p); }),
-    slider('Inner α',0,.9,.01,.45,'',(p,v)=>{ p._r2=v; p._inset = p._rims(); rebuildShadow(p); }),
+    slider('Inner α',0,.9,.01,.40,'',(p,v)=>{ p._r2=v; p._inset = p._rims(); rebuildShadow(p); }),
     ...outerShadowSliders(26,.22), borderWidthSlider(0), borderAlphaSlider(.12)
   ],
   buildCSS: buildSimpleCSS
 });
 
-/* === 11 Neon Gradient Border === */
+/* === 11 Spectrum Glow === */
 CARDS.push({
-  id:'neon', title:'Neon Gradient Border', key:'gradient rim + glow',
+  id:'spectrum', title:'Spectrum Glow', key:'gradient rim + glow',
   setup(p){
-    p._bgcol='13,14,35'; p.style.position='relative'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
-    p._bw=2; p._ba=0; p.style.border='2px solid transparent';
-    p._angle=135; p._glowBlur=14; p._glowA=.9;
-    p.style.backgroundImage='linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)';
+    p._bgcol='13,14,35'; p.style.position='relative'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,14,125);
+    p._bw=1; p.style.border='1px solid transparent';
+    p._angle=45; p._glowBlur=20; p._glowA=.5;
+    p.style.backgroundImage=`linear-gradient(${p._angle}deg,#4fd1ff,#a855f7)`;
     p.style.backgroundOrigin='border-box'; p.style.backgroundClip='padding-box, border-box';
-    const glow=el('div'); glow.className='neonGlow'; Object.assign(glow.style,{
-      position:'absolute', inset:'-2px', borderRadius:'inherit', pointerEvents:'none',
-      background:'linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)', filter:'blur(14px)', opacity:'0.9',
+    const glow=el('div'); glow.className='spectrumGlow'; Object.assign(glow.style,{
+      position:'absolute', inset:'-1px', borderRadius:'inherit', pointerEvents:'none',
+      background:`linear-gradient(${p._angle}deg,#4fd1ff,#a855f7)`, filter:`blur(${p._glowBlur}px)`, opacity:String(p._glowA),
       WebkitMask:'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-      WebkitMaskComposite:'xor', maskComposite:'exclude', padding:'2px'
+      WebkitMaskComposite:'xor', maskComposite:'exclude', padding:'1px'
     }); p.appendChild(glow);
   },
   sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Border width px',0,10,1,2,'px',(p,v)=>{ p._bw=v; p.style.borderWidth=v+'px'; const g=p.querySelector('.neonGlow'); g.style.inset = (-v)+'px'; g.style.padding = v+'px'; }),
-    slider('Glow blur px',0,60,1,14,'px',(p,v)=>{ p._glowBlur=v; p.querySelector('.neonGlow').style.filter=`blur(${v}px)`; }),
-    slider('Glow opacity',0,1,.01,.9,'',(p,v)=>{ p._glowA=v; p.querySelector('.neonGlow').style.opacity=String(v); }),
-    slider('Angle °',0,360,1,135,'deg',(p,v)=>{ p._angle=v; p.style.backgroundImage=`linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; p.querySelector('.neonGlow').style.background=`linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; })
+    bgAlphaSlider(.14), ...baseBlurSat(14,125),
+    slider('Border px',0,6,1,1,'px',(p,v)=>{ p._bw=v; p.style.borderWidth=v+'px'; const g=p.querySelector('.spectrumGlow'); g.style.inset=(-v)+'px'; g.style.padding=v+'px'; }),
+    slider('Glow blur px',0,40,1,20,'px',(p,v)=>{ p._glowBlur=v; p.querySelector('.spectrumGlow').style.filter=`blur(${v}px)`; }),
+    slider('Glow α',0,1,.01,.5,'',(p,v)=>{ p._glowA=v; p.querySelector('.spectrumGlow').style.opacity=String(v); }),
+    slider('Angle °',0,360,1,45,'deg',(p,v)=>{ p._angle=v; p.style.backgroundImage=`linear-gradient(${v}deg,#4fd1ff,#a855f7)`; p.querySelector('.spectrumGlow').style.background=`linear-gradient(${v}deg,#4fd1ff,#a855f7)`; })
   ],
   buildCSS(p){
     const mainCss = [];
     writeBaseCSS(p,mainCss);
-    mainCss.push(`background-image: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${p._angle}deg,#00ffd5,#7a5cff,#ff00e6);`);
+    mainCss.push(`background-image: linear-gradient(${p._angle}deg,#4fd1ff,#a855f7);`);
     mainCss.push(`background-origin: border-box;`);
     mainCss.push(`background-clip: padding-box, border-box;`);
 
-    const s = getComputedStyle(p.querySelector('.neonGlow'));
+    const s = getComputedStyle(p.querySelector('.spectrumGlow'));
     const pseudoCss = [
       'content: ""',
       'position: absolute',
@@ -461,39 +491,37 @@ CARDS.push({
   }
 });
 
-/* === 12 Duotone Prism Edge === */
+/* === 12 Switcher Chrome === */
 CARDS.push({
-  id:'duoprism', title:'Duotone Prism Edge', key:'two inner rims',
+  id:'switcher', title:'Switcher Chrome', key:'multi reflex shadows',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,125);
-    p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
-    p._oblur=26; p._oalpha=.20; rebuildShadow(p);
-    p._rimThk=2; p._cA=.55; p._mA=.55;
-    const rim=el('div'); rim.className='duoRim'; p.appendChild(rim);
-    function paint(){ rim.style.position='absolute'; rim.style.inset='0'; rim.style.pointerEvents='none'; rim.style.borderRadius='inherit';
-      rim.style.boxShadow=`inset 0 0 0 1px rgba(0,255,255,${p._cA}), inset 0 0 0 ${p._rimThk}px rgba(255,0,255,${p._mA})`; }
-    p._paintRim=paint; paint();
+    p._bgcol='187,187,188'; p.style.backgroundColor='rgba(187,187,188,0.12)';
+    p._blur=8; p._sat=150; setBlurSat(p,p._blur,p._sat);
+    p._light=2; p._dark=.3;
+    function paint(){
+      p.style.boxShadow=
+        `inset 0 0 0 1px rgba(255,255,255,${p._light*0.1}),`+
+        `inset 1.8px 3px 0px -2px rgba(255,255,255,${p._light*0.9}),`+
+        `inset -2px -2px 0px -2px rgba(255,255,255,${p._light*0.8}),`+
+        `inset -3px -8px 1px -6px rgba(255,255,255,${p._light*0.6}),`+
+        `inset -0.3px -1px 4px 0px rgba(0,0,0,${p._dark*0.12}),`+
+        `inset -1.5px 2.5px 0px -2px rgba(0,0,0,${p._dark*0.20}),`+
+        `inset 0px 3px 4px -2px rgba(0,0,0,${p._dark*0.20}),`+
+        `inset 2px -6.5px 1px -4px rgba(0,0,0,${p._dark*0.10}),`+
+        `0px 1px 5px 0px rgba(0,0,0,${p._dark*0.10}),`+
+        `0px 6px 16px 0px rgba(0,0,0,${p._dark*0.08})`;
+    }
+    p._paint=paint; paint();
+    p._bw=0; p._ba=.12; p.style.border='0px solid rgba(255,255,255,.12)';
   },
   sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,125),
-    slider('Rim thickness px',1,10,1,2,'px',(p,v)=>{ p._rimThk=v; p._paintRim(); }),
-    slider('Cyan α',0,1,.01,.55,'',(p,v)=>{ p._cA=v; p._paintRim(); }),
-    slider('Magenta α',0,1,.01,.55,'',(p,v)=>{ p._mA=v; p._paintRim(); }),
-    ...outerShadowSliders(26,.20), borderWidthSlider(1), borderAlphaSlider(.10)
+    bgAlphaSlider(.12),
+    slider('Blur px',0,30,1,8,'px',(p,v)=>{ p._blur=v; setBlurSat(p,p._blur,p._sat); }),
+    slider('Saturate %',60,260,1,150,'%',(p,v)=>{ p._sat=v; setBlurSat(p,p._blur,p._sat); }),
+    slider('Light reflex',0,2,.01,2,'',(p,v)=>{ p._light=v; p._paint(); }),
+    slider('Dark reflex',0,2,.01,.3,'',(p,v)=>{ p._dark=v; p._paint(); })
   ],
-  buildCSS(p){
-    return buildOverlayCSS(p, 'after', (p) => {
-      const s = getComputedStyle(p.querySelector('.duoRim'));
-      return [
-        'content: ""',
-        'position: absolute',
-        'inset: 0',
-        'pointer-events: none',
-        'border-radius: inherit',
-        `box-shadow: ${s.boxShadow}`
-      ];
-    });
-  }
+  buildCSS: buildSimpleCSS
 });
 
 /* === 13 Ringed Glass === */
@@ -505,13 +533,14 @@ CARDS.push({
     const fx=el('div'); fx.className='ringsFx'; p.appendChild(fx);
     function paint(){ Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
-      background:`repeating-radial-gradient(circle at ${p._cx}% ${p._cy}%, rgba(255,255,255,0.14), rgba(255,255,255,0.14) ${p._dot}px, transparent ${p._dot}px, transparent ${p._gap}px)`
+      background:`repeating-radial-gradient(circle at ${p._cx}% ${p._cy}%, hsla(${p._h},70%,80%,0.14), hsla(${p._h},70%,80%,0.14) ${p._dot}px, transparent ${p._dot}px, transparent ${p._gap}px)`
     }); }
-    p._cx=50;p._cy=50;p._dot=2;p._gap=10;p._op=.35; p._paint=paint; paint();
+    p._cx=50;p._cy=50;p._dot=2;p._gap=10;p._op=.40;p._h=0; p._paint=paint; paint();
   },
   sliders:[
     bgAlphaSlider(.14), ...baseBlurSat(10,120),
-    slider('Rings α',0,1,.01,.35,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Rings α',0,1,.01,.40,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Hue °',0,360,1,0,'deg',(p,v)=>{ p._h=v; p._paint(); }),
     slider('Center X %',0,100,1,50,'%',(p,v)=>{ p._cx=v; p._paint(); }),
     slider('Center Y %',0,100,1,50,'%',(p,v)=>{ p._cy=v; p._paint(); }),
     slider('Dot px',1,8,1,2,'px',(p,v)=>{ p._dot=v; p._paint(); }),
@@ -543,14 +572,15 @@ CARDS.push({
     const fx=el('div'); fx.className='scratchFx'; p.appendChild(fx);
     function paint(){ Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
-      background:`repeating-linear-gradient(${p._ang}deg, rgba(255,255,255,.5), rgba(255,255,255,.5) ${p._line}px, transparent ${p._line}px, transparent ${p._gap}px)`
+      background:`repeating-linear-gradient(${p._ang}deg, hsla(${p._h},100%,90%,.5), hsla(${p._h},100%,90%,.5) ${p._line}px, transparent ${p._line}px, transparent ${p._gap}px)`
     }); }
-    p._ang=20;p._line=1;p._gap=6;p._op=.35; p._paint=paint; paint();
+    p._ang=25;p._line=1;p._gap=6;p._op=.40;p._h=0; p._paint=paint; paint();
   },
   sliders:[
     bgAlphaSlider(.14), ...baseBlurSat(10,120),
-    slider('Scratch α',0,1,.01,.35,'',(p,v)=>{ p._op=v; p._paint(); }),
-    slider('Angle °',0,180,1,20,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
+    slider('Scratch α',0,1,.01,.40,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Angle °',0,180,1,25,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
+    slider('Hue °',0,360,1,0,'deg',(p,v)=>{ p._h=v; p._paint(); }),
     slider('Line px',1,4,1,1,'px',(p,v)=>{ p._line=v; p._paint(); }),
     slider('Gap px',4,20,1,6,'px',(p,v)=>{ p._gap=v; p._paint(); }),
     borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(26,.22)
@@ -582,11 +612,11 @@ CARDS.push({
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
       background:`linear-gradient(${p._ang}deg, rgba(255,0,153,.25), rgba(0,255,204,.25), rgba(0,128,255,.25))`
     }); }
-    p._ang=130;p._op=.55; p._paint=paint; paint();
+    p._ang=130;p._op=.50; p._paint=paint; paint();
   },
   sliders:[
     bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Overlay α',0,1,.01,.55,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Overlay α',0,1,.01,.50,'',(p,v)=>{ p._op=v; p._paint(); }),
     slider('Angle °',0,360,1,130,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
     borderWidthSlider(1), borderAlphaSlider(.10), ...outerShadowSliders(28,.22)
   ],


### PR DESCRIPTION
## Summary
- replace legacy styles with 7 new iOS 26-inspired liquid glass looks
- tune remaining styles' default slider values and add color controls where useful

## Testing
- `npx prettier --check CSS-GLASS-STYLES.html` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc599aa48832e978f7518e7844bd7