### PR TITLE
feat: refine liquid glass styles

### DIFF
--- a/CSS-GLASS-STYLES.html
+++ b/CSS-GLASS-STYLES.html
@@ -30,9 +30,9 @@
     backdrop-filter: blur(10px) saturate(120%);
     border-bottom: 1px solid rgba(255,255,255,.08);
   }
-  .wrap{max-width:1280px;margin:0 auto;padding:14px 18px}
-  h1{font-size:18px;letter-spacing:.3px;margin:0}
-  .grid{max-width:1280px;margin:24px auto 64px;padding:0 16px;display:grid;grid-template-columns:repeat(auto-fill,minmax(380px,1fr));gap:18px}
+  .wrap{max-width:1280px;margin:0 auto;padding:12px 16px}
+  h1{font-size:16px;letter-spacing:.3px;margin:0}
+  .grid{max-width:1280px;margin:20px auto 60px;padding:0 14px;display:grid;grid-template-columns:repeat(auto-fill,minmax(380px,1fr));gap:16px}
 
   /* ── PANEL / CONTAINER — transparent, no blur here ── */
   .card{
@@ -42,10 +42,10 @@
         /* no backdrop-filter here — it interferes with previews' blur slider */
         box-shadow: 0 6px 18px rgba(0,0,0,.12);
   }
-  .card .bar{display:flex;align-items:center;gap:8px;padding:10px 12px;
+  .card .bar{display:flex;align-items:center;gap:8px;padding:8px 10px;
              background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,0));
-             font-weight:700;font-size:14px}
-  .card .sub{padding:0 12px 6px;color:var(--muted);font-size:12px}
+             font-weight:700;font-size:12px}
+  .card .sub{padding:0 10px 4px;color:var(--muted);font-size:10px}
 
   /* Preview area (the actual “glass” demo) */
   .preview{min-height:240px;border-top:1px dashed rgba(255,255,255,.12);border-bottom:1px dashed rgba(255,255,255,.12);
@@ -53,14 +53,14 @@
 
   /* Slider panel */
   .controls{background:transparent}
-  .ctl{display:grid;grid-template-columns:1fr auto;gap:10px;align-items:center;padding:6px 12px}
-  .ctl label{font-size:12px;color:var(--muted)}
-  .ctl input[type=range]{width:100%}
+  .ctl{display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center;padding:4px 10px}
+  .ctl label{font-size:10px;color:var(--muted)}
+  .ctl input[type=range]{width:100%;height:4px}
 
-  pre.code{margin:8px 12px 12px;padding:10px;background:rgba(0,0,0,.16);
-           border-radius:10px;border:1px solid rgba(255,255,255,.08);font-size:11px;color:#f4f5ff;overflow:auto;max-height:250px;white-space:pre-wrap}
-  .btns{display:flex;gap:8px;margin:0 12px 14px}
-  button.btn{padding:8px 12px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);color:#fff;cursor:pointer}
+  pre.code{margin:6px 10px 10px;padding:8px;background:rgba(0,0,0,.16);
+           border-radius:10px;border:1px solid rgba(255,255,255,.08);font-size:10px;color:#f4f5ff;overflow:auto;max-height:250px;white-space:pre-wrap}
+  .btns{display:flex;gap:6px;margin:0 10px 12px}
+  button.btn{padding:6px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);color:#fff;cursor:pointer;font-size:10px}
 
   .err{padding:10px 12px;color:#ffb4b4}
 </style>
@@ -172,59 +172,135 @@ function bgAlphaSlider(initA=0.12){
 
 const CARDS=[];
 
-/* === 1 Soft === */
+/* === 1 Dual Edge Diffusion === */
 CARDS.push({
-  id:'soft', title:'Soft Glass', key:'blur · saturate · base α',
+  id:'midnight', title:'Dual Edge Diffusion', key:'balanced radial glow',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.10)'; setBlurSat(p,6,110);
-    p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
-  },
-  sliders:[ bgAlphaSlider(.10), ...baseBlurSat(6,110), borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22) ],
-  buildCSS: buildSimpleCSS
-});
-
-/* === 2 Bright === */
-CARDS.push({
-  id:'bright', title:'Bright Glass', key:'blur + brightness↑',
-  setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; p._more='brightness(1.08)';
-    setBlurSat(p,12,125, p._more);
-    p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    p._bgcol='20,24,48'; p.style.backgroundColor='rgba(20,24,48,0.12)'; setBlurSat(p,14,150);
+    p._hA=.18; p._sA=.45;
+    p._edge=function(){
+      p._inset=`inset 1px 1px 1px rgba(255,255,255,${p._hA}), inset -1px -1px 1px rgba(0,0,0,${p._sA})`;
+      rebuildShadow(p);
+    };
+    p._oblur=28; p._oalpha=.22; p._edge();
+    p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
+    const fx=el('div'); fx.className='midFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
+      background:`radial-gradient(circle at ${p._cx}% ${p._cy}%, rgba(255,255,255,${p._gA}) 0%, rgba(255,255,255,0) ${p._gR}%)`
+    }); }
+    p._cx=50; p._cy=40; p._gA=.15; p._gR=60; p._paint=paint; paint();
   },
   sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,125),
-    slider('Brightness %',90,160,1,108,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p, p._blur??12, p._sat??125, p._more); }),
-    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
+    bgAlphaSlider(.12), ...baseBlurSat(14,150),
+    slider('Glow α',0,.4,.01,.15,'',(p,v)=>{ p._gA=v; p._paint(); }),
+    slider('Glow radius %',30,80,1,60,'%',(p,v)=>{ p._gR=v; p._paint(); }),
+    slider('Center X %',0,100,1,50,'%',(p,v)=>{ p._cx=v; p._paint(); }),
+    slider('Center Y %',0,100,1,40,'%',(p,v)=>{ p._cy=v; p._paint(); }),
+    slider('Edge highlight α',0,.4,.01,.18,'',(p,v)=>{ p._hA=v; p._edge(); }),
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(28,.22)
+  ],
+  buildCSS(p){
+    return buildOverlayCSS(p, 'after', (p) => {
+      const s = getComputedStyle(p.querySelector('.midFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `background: ${s.backgroundImage || s.background}`
+      ];
+    });
+  }
+});
+
+/* === 2 Switcher Panel === */
+CARDS.push({
+  id:'switchpanel', title:'Switcher Panel', key:'layered reflex edges',
+  setup(p){
+    p._bgcol='27,27,29'; p.style.backgroundColor='rgba(27,27,29,0.14)';
+    p._blur=8; p._sat=150; setBlurSat(p,8,150);
+    p._light=1; p._dark=1; p._ob=16; p._oa=.08;
+    function paint(){
+      const L=p._light, D=p._dark, ob=p._ob, oa=p._oa;
+      p.style.boxShadow=
+        `inset 0 0 0 1px rgba(255,255,255,${0.1*L}),`+
+        `inset 1.8px 3px 0 -2px rgba(255,255,255,${0.9*L}),`+
+        `inset -2px -2px 0 -2px rgba(255,255,255,${0.8*L}),`+
+        `inset -3px -8px 1px -6px rgba(255,255,255,${0.6*L}),`+
+        `inset -0.3px -1px 4px 0 rgba(0,0,0,${0.12*D}),`+
+        `inset -1.5px 2.5px 0 -2px rgba(0,0,0,${0.2*D}),`+
+        `inset 0 3px 4px -2px rgba(0,0,0,${0.2*D}),`+
+        `inset 2px -6.5px 1px -4px rgba(0,0,0,${0.1*D}),`+
+        `0 1px 5px 0 rgba(0,0,0,${0.1*D}),`+
+        `0 6px ${ob}px rgba(0,0,0,${oa})`;
+    }
+    p._paint=paint; paint();
+    p._bw=0; p._ba=0; p.style.border='0 solid transparent';
+  },
+  sliders:[
+    bgAlphaSlider(.14),
+    slider('Blur px',0,20,1,8,'px',(p,v)=>{ p._blur=v; setBlurSat(p,v,p._sat??150); }),
+    slider('Saturate %',80,220,1,150,'%',(p,v)=>{ p._sat=v; setBlurSat(p,p._blur??8,v); }),
+    slider('Light reflex',0,2,.01,1,'',(p,v)=>{ p._light=v; p._paint(); }),
+    slider('Dark reflex',0,2,.01,1,'',(p,v)=>{ p._dark=v; p._paint(); }),
+    slider('Outer blur px',0,40,1,16,'px',(p,v)=>{ p._ob=v; p._paint(); }),
+    slider('Outer α',0,.5,.01,.08,'',(p,v)=>{ p._oa=v; p._paint(); })
   ],
   buildCSS: buildSimpleCSS
 });
 
-/* === 3 Dimmed === */
+/* === 3 Lens Glow === */
 CARDS.push({
-  id:'dim', title:'Dimmed Glass', key:'blur + brightness↓',
+  id:'lens', title:'Lens Glow', key:'center highlight',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.26)'; p._more='brightness(0.90)';
-    setBlurSat(p,14,115, p._more);
-    p._inset=''; p._oblur=28; p._oalpha=.22; rebuildShadow(p);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.1)'; setBlurSat(p,14,140);
+    p._hA=.16; p._sA=.4;
+    p._edge=function(){
+      p._inset=`inset 1px 1px 1px rgba(255,255,255,${p._hA}), inset -1px -1px 1px rgba(0,0,0,${p._sA})`;
+      rebuildShadow(p);
+    };
+    p._oblur=28; p._oalpha=.22; p._edge();
     p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    const fx=el('div'); fx.className='lensFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute', inset:'0', pointerEvents:'none', borderRadius:'inherit',
+      background:`radial-gradient(circle at ${p._cx}% ${p._cy}%, rgba(255,255,255,${p._a}), rgba(255,255,255,0) ${p._r}%)`
+    }); }
+    p._cx=50; p._cy=45; p._r=55; p._a=.25; p._paint=paint; paint();
   },
   sliders:[
-    bgAlphaSlider(.26), ...baseBlurSat(14,115),
-    slider('Brightness %',60,120,1,90,'%',(p,v)=>{ p._more=`brightness(${v/100})`; setBlurSat(p, p._blur??14, p._sat??115, p._more); }),
+    bgAlphaSlider(.1), ...baseBlurSat(14,140),
+    slider('Glow α',0,.6,.01,.25,'',(p,v)=>{ p._a=v; p._paint(); }),
+    slider('Glow size %',20,80,1,55,'%',(p,v)=>{ p._r=v; p._paint(); }),
+    slider('Center X %',0,100,1,50,'%',(p,v)=>{ p._cx=v; p._paint(); }),
+    slider('Center Y %',0,100,1,45,'%',(p,v)=>{ p._cy=v; p._paint(); }),
+    slider('Edge highlight α',0,.4,.01,.16,'',(p,v)=>{ p._hA=v; p._edge(); }),
     borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
   ],
-  buildCSS: buildSimpleCSS
+  buildCSS(p){
+    return buildOverlayCSS(p, 'after', (p) => {
+      const s = getComputedStyle(p.querySelector('.lensFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `background: ${s.backgroundImage || s.background}`
+      ];
+    });
+  }
 });
 
 /* === 4 Acrylic === */
 CARDS.push({
   id:'acrylic', title:'Acrylic', key:'blur · saturate · dotted noise',
   setup(p){
-    p._bgcol='20,28,58'; p.style.backgroundColor='rgba(20,28,58,0.06)'; setBlurSat(p,8,130);
-    p._inset=''; p._oblur=30; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    p._bgcol='20,28,58'; p.style.backgroundColor='rgba(20,28,58,0.10)'; setBlurSat(p,10,150);
+    p._inset=''; p._oblur=32; p._oalpha=.24; rebuildShadow(p);
+    p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
     const fx=el('div'); fx.className='noise'; Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
       backgroundImage:'radial-gradient(rgba(255,255,255,0.03) 1px, transparent 1px)',
@@ -232,10 +308,10 @@ CARDS.push({
     }); p.appendChild(fx);
   },
   sliders:[
-    bgAlphaSlider(.06), ...baseBlurSat(8,130),
-    slider('Noise α',0,.12,.001,.03,'',(p,v)=>{ p.querySelector('.noise').style.backgroundImage=`radial-gradient(rgba(255,255,255,${v}) 1px, transparent 1px)`; }),
-    slider('Noise size px',1,8,1,2,'px',(p,v)=>{ p.querySelector('.noise').style.backgroundSize=`${v}px ${v}px`; }),
-    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(30,.22)
+    bgAlphaSlider(.10), ...baseBlurSat(10,150),
+    slider('Noise α',0,.12,.001,.04,'',(p,v)=>{ p.querySelector('.noise').style.backgroundImage=`radial-gradient(rgba(255,255,255,${v}) 1px, transparent 1px)`; }),
+    slider('Noise size px',1,8,1,3,'px',(p,v)=>{ p.querySelector('.noise').style.backgroundSize=`${v}px ${v}px`; }),
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(32,.24)
   ],
   buildCSS(p){
     return buildOverlayCSS(p, 'after', (p) => {
@@ -257,20 +333,20 @@ CARDS.push({
 CARDS.push({
   id:'paper', title:'Paper Noise', key:'dual grain overlay',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.10)'; setBlurSat(p,10,120);
-    p._inset=''; p._oblur=30; p._oalpha=.20; rebuildShadow(p);
-    p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.10)'; setBlurSat(p,13,140);
+    p._inset=''; p._oblur=32; p._oalpha=.22; rebuildShadow(p);
+    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
     const fx=el('div'); fx.className='paperFx'; Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
       backgroundImage:'radial-gradient(rgba(255,255,255,.03) 1px, transparent 1px), radial-gradient(rgba(0,0,0,.06) 1px, transparent 1px)',
-      backgroundSize:'1px 1px, 2px 2px',opacity:'0.7'
+      backgroundSize:'1px 1px, 2px 2px',opacity:'0.6'
     }); p.appendChild(fx);
   },
   sliders:[
-    bgAlphaSlider(.10), ...baseBlurSat(10,120),
-    slider('Grain opacity',0,1,.01,.7,'',(p,v)=>{ p.querySelector('.paperFx').style.opacity=String(v); }),
-    slider('Grain size px',1,8,1,1,'px',(p,v)=>{ p.querySelector('.paperFx').style.backgroundSize=`${v}px ${v}px, ${v*2}px ${v*2}px`; }),
-    borderWidthSlider(1), borderAlphaSlider(.10), ...outerShadowSliders(30,.20)
+    bgAlphaSlider(.10), ...baseBlurSat(13,140),
+    slider('Grain opacity',0,1,.01,.6,'',(p,v)=>{ p.querySelector('.paperFx').style.opacity=String(v); }),
+    slider('Grain size px',1,8,1,2,'px',(p,v)=>{ p.querySelector('.paperFx').style.backgroundSize=`${v}px ${v}px, ${v*2}px ${v*2}px`; }),
+    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(32,.22)
   ],
   buildCSS(p){
     return buildOverlayCSS(p, 'after', (p) => {
@@ -293,22 +369,22 @@ CARDS.push({
 CARDS.push({
   id:'gloss', title:'Glossy Highlight', key:'top sheen',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
-    p._inset=''; p._oblur=30; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,14,130);
+    p._inset=''; p._oblur=32; p._oalpha=.24; rebuildShadow(p);
+    p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
     const fx=el('div'); fx.className='glossFx'; p.appendChild(fx);
     function paint(){ Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
       background:`linear-gradient(${p._sheenAngle}deg, rgba(255,255,255,${p._sheenA}), rgba(255,255,255,0) ${p._sheenStop}%)`
     }); }
-    p._sheenAngle=180; p._sheenStop=35; p._sheenA=.18; p._paint=paint; paint();
+    p._sheenAngle=180; p._sheenStop=40; p._sheenA=.24; p._paint=paint; paint();
   },
   sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Sheen α',0,.6,.01,.18,'',(p,v)=>{ p._sheenA=v; p._paint(); }),
-    slider('Sheen stop %',10,80,1,35,'%',(p,v)=>{ p._sheenStop=v; p._paint(); }),
+    bgAlphaSlider(.12), ...baseBlurSat(14,130),
+    slider('Sheen α',0,.6,.01,.24,'',(p,v)=>{ p._sheenA=v; p._paint(); }),
+    slider('Sheen stop %',10,80,1,40,'%',(p,v)=>{ p._sheenStop=v; p._paint(); }),
     slider('Sheen angle °',0,360,1,180,'deg',(p,v)=>{ p._sheenAngle=v; p._paint(); }),
-    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(30,.22)
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(32,.24)
   ],
   buildCSS(p){
     return buildOverlayCSS(p, 'before', (p) => {
@@ -325,198 +401,253 @@ CARDS.push({
   }
 });
 
-/* === 7 Tinted === */
+/* === 7 Aqua Ripple === */
 CARDS.push({
-  id:'tint', title:'Tinted (HSLA)', key:'tint hue · alpha',
+  id:'ripple', title:'Aqua Ripple', key:'conic wave overlay',
   setup(p){
-    p._h=270; p._tinta=.18;
-    p.style.backgroundColor=`hsla(${p._h},70%,45%,${p._tinta})`;
-    setBlurSat(p,12,120);
-    p._inset=''; p._oblur=30; p._oalpha=.22; rebuildShadow(p);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.10)'; setBlurSat(p,12,130);
+    p._hA=.16; p._sA=.4;
+    p._edge=function(){
+      p._inset=`inset 1px 1px 1px rgba(255,255,255,${p._hA}), inset -1px -1px 1px rgba(0,0,0,${p._sA})`;
+      rebuildShadow(p);
+    };
+    p._oblur=28; p._oalpha=.22; p._edge();
     p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    const fx=el('div'); fx.className='rippleFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
+      background:`repeating-conic-gradient(from ${p._ang}deg at 50% 50%, rgba(255,255,255,.08) 0deg, rgba(255,255,255,.08) ${p._freq}deg, transparent ${p._freq}deg, transparent ${p._freq*2}deg)`
+    }); }
+    p._ang=0; p._freq=20; p._op=.25; p._paint=paint; paint();
   },
   sliders:[
-    ...baseBlurSat(12,120),
-    slider('Tint hue °',0,360,1,270,'deg',(p,v)=>{ p._h=v; p.style.backgroundColor=`hsla(${p._h},70%,45%,${p._tinta})`; }),
-    slider('Tint α',0,.6,.01,.18,'',(p,v)=>{ p._tinta=v; p.style.backgroundColor=`hsla(${p._h},70%,45%,${p._tinta})`; }),
-    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(30,.22)
-  ],
-  buildCSS: buildSimpleCSS
-});
-
-/* === 8 Heavy Frost === */
-CARDS.push({
-  id:'frost', title:'Heavy Frost', key:'white frost',
-  setup(p){
-    p._fA=.16; p.style.backgroundColor=`rgba(255,255,255,${p._fA})`; setBlurSat(p,14,120);
-    p._inset=''; p._oblur=32; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.22; p.style.border='1px solid rgba(255,255,255,.22)';
-  },
-  sliders:[
-    ...baseBlurSat(14,120),
-    slider('Frost α',0,.6,.01,.16,'',(p,v)=>{ p._fA=v; p.style.backgroundColor=`rgba(255,255,255,${p._fA})`; }),
-    borderWidthSlider(1), borderAlphaSlider(.22), ...outerShadowSliders(32,.22)
-  ],
-  buildCSS: buildSimpleCSS
-});
-
-/* === 9 Inset Bevel === */
-CARDS.push({
-  id:'bevel', title:'Inset Bevel (4‑side)', key:'bevel px · light α · dark α',
-  setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.16)'; setBlurSat(p,12,118);
-    p._px=2; p._la=.35; p._da=.30;
-    p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`;
-    p._oblur=24; p._oalpha=.22; rebuildShadow(p);
-    p._bw=1; p._ba=.18; p.style.border='1px solid rgba(255,255,255,.18)';
-  },
-  sliders:[
-    bgAlphaSlider(.16), ...baseBlurSat(12,118),
-    slider('Bevel px',1,12,1,2,'px',(p,v)=>{ p._px=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Light α',.05,.8,.01,.35,'',(p,v)=>{ p._la=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    slider('Dark α',.05,.8,.01,.30,'',(p,v)=>{ p._da=v; p._inset = `inset 0 ${p._px}px 0 rgba(255,255,255,${p._la}), inset 0 -${p._px}px 0 rgba(0,0,0,${p._da}), inset ${p._px}px 0 0 rgba(0,0,0,${p._da}), inset -${p._px}px 0 0 rgba(255,255,255,${p._la})`; rebuildShadow(p); }),
-    ...outerShadowSliders(24,.22), borderWidthSlider(1), borderAlphaSlider(.18)
-  ],
-  buildCSS: buildSimpleCSS
-});
-
-/* === 10 Double Glass === */
-CARDS.push({
-  id:'double', title:'Double Glass', key:'outer rim · inner rim · alphas',
-  setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,12,120);
-    p._outerPx=12; p._innerPx=2; p._r1=.20; p._r2=.45;
-    p._rims = ()=> `inset 0 0 0 ${p._outerPx}px rgba(255,255,255,${p._r1}), inset 0 0 0 ${p._innerPx}px rgba(255,255,255,${p._r2})`;
-    p._inset = p._rims();
-    p._oblur=26; p._oalpha=.22; rebuildShadow(p);
-    p._bw=0; p._ba=.12; p.style.border='0px solid rgba(255,255,255,.12)';
-  },
-  sliders:[
-    bgAlphaSlider(.14), ...baseBlurSat(12,120),
-    slider('Outer rim px',0,30,1,12,'px',(p,v)=>{ p._outerPx=v; p._inset = p._rims(); rebuildShadow(p); }),
-    slider('Outer α',0,.6,.01,.20,'',(p,v)=>{ p._r1=v; p._inset = p._rims(); rebuildShadow(p); }),
-    slider('Inner rim px',0,12,1,2,'px',(p,v)=>{ p._innerPx=v; p._inset = p._rims(); rebuildShadow(p); }),
-    slider('Inner α',0,.9,.01,.45,'',(p,v)=>{ p._r2=v; p._inset = p._rims(); rebuildShadow(p); }),
-    ...outerShadowSliders(26,.22), borderWidthSlider(0), borderAlphaSlider(.12)
-  ],
-  buildCSS: buildSimpleCSS
-});
-
-/* === 11 Neon Gradient Border === */
-CARDS.push({
-  id:'neon', title:'Neon Gradient Border', key:'gradient rim + glow',
-  setup(p){
-    p._bgcol='13,14,35'; p.style.position='relative'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
-    p._bw=2; p._ba=0; p.style.border='2px solid transparent';
-    p._angle=135; p._glowBlur=14; p._glowA=.9;
-    p.style.backgroundImage='linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)';
-    p.style.backgroundOrigin='border-box'; p.style.backgroundClip='padding-box, border-box';
-    const glow=el('div'); glow.className='neonGlow'; Object.assign(glow.style,{
-      position:'absolute', inset:'-2px', borderRadius:'inherit', pointerEvents:'none',
-      background:'linear-gradient(135deg,#00ffd5,#7a5cff,#ff00e6)', filter:'blur(14px)', opacity:'0.9',
-      WebkitMask:'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-      WebkitMaskComposite:'xor', maskComposite:'exclude', padding:'2px'
-    }); p.appendChild(glow);
-  },
-  sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Border width px',0,10,1,2,'px',(p,v)=>{ p._bw=v; p.style.borderWidth=v+'px'; const g=p.querySelector('.neonGlow'); g.style.inset = (-v)+'px'; g.style.padding = v+'px'; }),
-    slider('Glow blur px',0,60,1,14,'px',(p,v)=>{ p._glowBlur=v; p.querySelector('.neonGlow').style.filter=`blur(${v}px)`; }),
-    slider('Glow opacity',0,1,.01,.9,'',(p,v)=>{ p._glowA=v; p.querySelector('.neonGlow').style.opacity=String(v); }),
-    slider('Angle °',0,360,1,135,'deg',(p,v)=>{ p._angle=v; p.style.backgroundImage=`linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; p.querySelector('.neonGlow').style.background=`linear-gradient(${v}deg,#00ffd5,#7a5cff,#ff00e6)`; })
-  ],
-  buildCSS(p){
-    const mainCss = [];
-    writeBaseCSS(p,mainCss);
-    mainCss.push(`background-image: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)), linear-gradient(${p._angle}deg,#00ffd5,#7a5cff,#ff00e6);`);
-    mainCss.push(`background-origin: border-box;`);
-    mainCss.push(`background-clip: padding-box, border-box;`);
-
-    const s = getComputedStyle(p.querySelector('.neonGlow'));
-    const pseudoCss = [
-      'content: ""',
-      'position: absolute',
-      `inset: -${p._bw}px`,
-      'pointer-events: none',
-      'border-radius: inherit',
-      `padding: ${p._bw}px`,
-      `opacity: ${p._glowA}`,
-      `background: ${s.background}`,
-      `filter: blur(${p._glowBlur}px)`,
-      '-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
-      '-webkit-mask-composite: xor',
-      'mask-composite: exclude'
-    ];
-
-    const finalCss = [
-      `.your-selector {`,
-      ...mainCss.map(line => `  ${line}`),
-      `}`,
-      ``,
-      `.your-selector::after {`,
-      ...pseudoCss.map(line => `  ${line}`),
-      `}`
-    ];
-    return finalCss.join('\n');
-  }
-});
-
-/* === 12 Duotone Prism Edge === */
-CARDS.push({
-  id:'duoprism', title:'Duotone Prism Edge', key:'two inner rims',
-  setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,125);
-    p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
-    p._oblur=26; p._oalpha=.20; rebuildShadow(p);
-    p._rimThk=2; p._cA=.55; p._mA=.55;
-    const rim=el('div'); rim.className='duoRim'; p.appendChild(rim);
-    function paint(){ rim.style.position='absolute'; rim.style.inset='0'; rim.style.pointerEvents='none'; rim.style.borderRadius='inherit';
-      rim.style.boxShadow=`inset 0 0 0 1px rgba(0,255,255,${p._cA}), inset 0 0 0 ${p._rimThk}px rgba(255,0,255,${p._mA})`; }
-    p._paintRim=paint; paint();
-  },
-  sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,125),
-    slider('Rim thickness px',1,10,1,2,'px',(p,v)=>{ p._rimThk=v; p._paintRim(); }),
-    slider('Cyan α',0,1,.01,.55,'',(p,v)=>{ p._cA=v; p._paintRim(); }),
-    slider('Magenta α',0,1,.01,.55,'',(p,v)=>{ p._mA=v; p._paintRim(); }),
-    ...outerShadowSliders(26,.20), borderWidthSlider(1), borderAlphaSlider(.10)
+    bgAlphaSlider(.10), ...baseBlurSat(12,130),
+    slider('Ripple α',0,1,.01,.25,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Frequency °',6,60,1,20,'deg',(p,v)=>{ p._freq=v; p._paint(); }),
+    slider('Angle °',0,360,1,0,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
+    slider('Edge highlight α',0,.4,.01,.16,'',(p,v)=>{ p._hA=v; p._edge(); }),
+    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(28,.22)
   ],
   buildCSS(p){
     return buildOverlayCSS(p, 'after', (p) => {
-      const s = getComputedStyle(p.querySelector('.duoRim'));
+      const s = getComputedStyle(p.querySelector('.rippleFx'));
       return [
         'content: ""',
         'position: absolute',
         'inset: 0',
         'pointer-events: none',
         'border-radius: inherit',
-        `box-shadow: ${s.boxShadow}`
+        `opacity: ${s.opacity}`,
+        `background: ${s.backgroundImage}`
       ];
     });
   }
+});
+
+/* === 8 Carbon Mesh === */
+CARDS.push({
+  id:'mesh', title:'Carbon Mesh', key:'crosshatch texture',
+  setup(p){
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,135);
+    p._hA=.18; p._sA=.45;
+    p._edge=function(){
+      p._inset=`inset 1px 1px 1px rgba(255,255,255,${p._hA}), inset -1px -1px 1px rgba(0,0,0,${p._sA})`;
+      rebuildShadow(p);
+    };
+    p._oblur=32; p._oalpha=.22; p._edge();
+    p._bw=1; p._ba=.16; p.style.border='1px solid rgba(255,255,255,.16)';
+    const fx=el('div'); fx.className='meshFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
+      background:`repeating-linear-gradient(0deg, rgba(255,255,255,${p._op}) 0 1px, transparent 1px ${p._size}px), repeating-linear-gradient(90deg, rgba(255,255,255,${p._op}) 0 1px, transparent 1px ${p._size}px)`
+    }); }
+    p._op=.15; p._size=8; p._paint=paint; paint();
+  },
+  sliders:[
+    bgAlphaSlider(.12), ...baseBlurSat(12,135),
+    slider('Mesh α',0,.4,.01,.15,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Cell px',4,20,1,8,'px',(p,v)=>{ p._size=v; p._paint(); }),
+    slider('Edge highlight α',0,.4,.01,.18,'',(p,v)=>{ p._hA=v; p._edge(); }),
+    borderWidthSlider(1), borderAlphaSlider(.16), ...outerShadowSliders(32,.22)
+  ],
+  buildCSS(p){
+    return buildOverlayCSS(p, 'after', (p) => {
+      const s = getComputedStyle(p.querySelector('.meshFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `opacity: ${s.opacity}`,
+        `background: ${s.backgroundImage}`
+      ];
+    });
+  }
+});
+
+/* === 9 Prismatic Sheen === */
+CARDS.push({
+  id:'sheen', title:'Prismatic Sheen', key:'multicolor linear overlay',
+  setup(p){
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,135);
+    p._hA=.18; p._sA=.45;
+    p._edge=function(){
+      p._inset=`inset 1px 1px 1px rgba(255,255,255,${p._hA}), inset -1px -1px 1px rgba(0,0,0,${p._sA})`;
+      rebuildShadow(p);
+    };
+    p._oblur=24; p._oalpha=.22; p._edge();
+    p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
+    const fx=el('div'); fx.className='sheenFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
+      background:`linear-gradient(${p._ang}deg, rgba(255,0,180,${p._op}), rgba(0,255,200,${p._op}), rgba(0,100,255,${p._op}))`
+    }); }
+    p._ang=125; p._op=.4; p._paint=paint; paint();
+  },
+  sliders:[
+    bgAlphaSlider(.12), ...baseBlurSat(12,135),
+    slider('Sheen α',0,1,.01,.4,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Angle °',0,360,1,125,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
+    slider('Edge highlight α',0,.4,.01,.18,'',(p,v)=>{ p._hA=v; p._edge(); }),
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(24,.22)
+  ],
+  buildCSS(p){
+    return buildOverlayCSS(p, 'after', (p) => {
+      const s = getComputedStyle(p.querySelector('.sheenFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `opacity: ${s.opacity}`,
+        `background: ${s.backgroundImage || s.background}`
+      ];
+    });
+  }
+});
+
+/* === 10 Double Glass === */
+CARDS.push({
+  id:'double', title:'Double Glass', key:'outer rim · inner rim · alphas',
+  setup(p){
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,16,140);
+    p._outerPx=12; p._innerPx=3; p._r1=.20; p._r2=.50;
+    p._rims = ()=> `inset 0 0 0 ${p._outerPx}px rgba(255,255,255,${p._r1}), inset 0 0 0 ${p._innerPx}px rgba(255,255,255,${p._r2})`;
+    p._inset = p._rims();
+    p._oblur=28; p._oalpha=.24; rebuildShadow(p);
+    p._bw=0; p._ba=.14; p.style.border='0px solid rgba(255,255,255,.14)';
+  },
+  sliders:[
+    bgAlphaSlider(.14), ...baseBlurSat(16,140),
+    slider('Outer rim px',0,30,1,12,'px',(p,v)=>{ p._outerPx=v; p._inset = p._rims(); rebuildShadow(p); }),
+    slider('Outer α',0,.6,.01,.20,'',(p,v)=>{ p._r1=v; p._inset = p._rims(); rebuildShadow(p); }),
+    slider('Inner rim px',0,12,1,3,'px',(p,v)=>{ p._innerPx=v; p._inset = p._rims(); rebuildShadow(p); }),
+    slider('Inner α',0,.9,.01,.50,'',(p,v)=>{ p._r2=v; p._inset = p._rims(); rebuildShadow(p); }),
+    ...outerShadowSliders(28,.24), borderWidthSlider(0), borderAlphaSlider(.14)
+  ],
+  buildCSS: buildSimpleCSS
+});
+
+/* === 11 Deep Halo === */
+CARDS.push({
+  id:'halo', title:'Deep Halo', key:'inner radial ring',
+  setup(p){
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,140);
+    p._hA=.16; p._sA=.4;
+    p._edge=function(){
+      p._inset=`inset 1px 1px 1px rgba(255,255,255,${p._hA}), inset -1px -1px 1px rgba(0,0,0,${p._sA})`;
+      rebuildShadow(p);
+    };
+    p._oblur=26; p._oalpha=.22; p._edge();
+    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    const fx=el('div'); fx.className='haloFx'; p.appendChild(fx);
+    function paint(){ Object.assign(fx.style,{
+      position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',
+      background:`radial-gradient(circle at 50% 50%, rgba(255,255,255,0) ${p._inner}%, rgba(255,255,255,${p._ha}) ${p._inner}%, rgba(255,255,255,0) ${p._inner + p._thick}%)`
+    }); }
+    p._inner=40; p._thick=20; p._ha=.25; p._paint=paint; paint();
+  },
+  sliders:[
+    bgAlphaSlider(.12), ...baseBlurSat(12,140),
+    slider('Halo α',0,.6,.01,.25,'',(p,v)=>{ p._ha=v; p._paint(); }),
+    slider('Inner %',20,60,1,40,'%',(p,v)=>{ p._inner=v; p._paint(); }),
+    slider('Thickness %',5,40,1,20,'%',(p,v)=>{ p._thick=v; p._paint(); }),
+    slider('Edge highlight α',0,.4,.01,.16,'',(p,v)=>{ p._hA=v; p._edge(); }),
+    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(26,.22)
+  ],
+  buildCSS(p){
+    return buildOverlayCSS(p, 'after', (p) => {
+      const s = getComputedStyle(p.querySelector('.haloFx'));
+      return [
+        'content: ""',
+        'position: absolute',
+        'inset: 0',
+        'pointer-events: none',
+        'border-radius: inherit',
+        `background: ${s.backgroundImage || s.background}`
+      ];
+    });
+  }
+});
+
+/* === 12 Switcher Reflex === */
+CARDS.push({
+  id:'switcher', title:'Switcher Reflex', key:'multi inset shadows',
+  setup(p){
+    p._bgcol='27,27,29'; p.style.backgroundColor='rgba(27,27,29,0.14)'; setBlurSat(p,8,150);
+    p._light=1; p._dark=1; p._oblur=16; p._oalpha=.08;
+    function paint(){
+      const L=p._light, D=p._dark, ob=p._oblur, oa=p._oalpha;
+      p.style.boxShadow=
+        `inset 0 0 0 1px rgba(255,255,255,${0.1*L}),`+
+        `inset 1.8px 3px 0 -2px rgba(255,255,255,${0.9*L}),`+
+        `inset -2px -2px 0 -2px rgba(255,255,255,${0.8*L}),`+
+        `inset -3px -8px 1px -6px rgba(255,255,255,${0.6*L}),`+
+        `inset -0.3px -1px 4px 0 rgba(0,0,0,${0.12*D}),`+
+        `inset -1.5px 2.5px 0 -2px rgba(0,0,0,${0.2*D}),`+
+        `inset 0 3px 4px -2px rgba(0,0,0,${0.2*D}),`+
+        `inset 2px -6.5px 1px -4px rgba(0,0,0,${0.1*D}),`+
+        `0 1px 5px 0 rgba(0,0,0,${0.1*D}),`+
+        `0 6px ${ob}px rgba(0,0,0,${oa})`;
+    }
+    p._paint=paint; paint();
+    p._bw=0; p._ba=0; p.style.border='0px solid transparent';
+  },
+  sliders:[
+    bgAlphaSlider(.14),
+    slider('Blur px',0,20,1,8,'px',(p,v)=>{ p._blur=v; setBlurSat(p,v,p._sat??150); }),
+    slider('Saturate %',80,220,1,150,'%',(p,v)=>{ p._sat=v; setBlurSat(p,p._blur??8,v); }),
+    slider('Light reflex',0,2,.01,1,'',(p,v)=>{ p._light=v; p._paint(); }),
+    slider('Dark reflex',0,2,.01,1,'',(p,v)=>{ p._dark=v; p._paint(); }),
+    slider('Outer blur px',0,40,1,16,'px',(p,v)=>{ p._oblur=v; p._paint(); }),
+    slider('Outer α',0,.5,.01,.08,'',(p,v)=>{ p._oalpha=v; p._paint(); })
+  ],
+  buildCSS: buildSimpleCSS
 });
 
 /* === 13 Ringed Glass === */
 CARDS.push({
   id:'rings', title:'Ringed Glass', key:'repeating radial · opacity',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,10,120);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,13,135);
     p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
     const fx=el('div'); fx.className='ringsFx'; p.appendChild(fx);
     function paint(){ Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
       background:`repeating-radial-gradient(circle at ${p._cx}% ${p._cy}%, rgba(255,255,255,0.14), rgba(255,255,255,0.14) ${p._dot}px, transparent ${p._dot}px, transparent ${p._gap}px)`
     }); }
-    p._cx=50;p._cy=50;p._dot=2;p._gap=10;p._op=.35; p._paint=paint; paint();
+    p._cx=50;p._cy=50;p._dot=3;p._gap=14;p._op=.45; p._paint=paint; paint();
   },
   sliders:[
-    bgAlphaSlider(.14), ...baseBlurSat(10,120),
-    slider('Rings α',0,1,.01,.35,'',(p,v)=>{ p._op=v; p._paint(); }),
+    bgAlphaSlider(.14), ...baseBlurSat(13,135),
+    slider('Rings α',0,1,.01,.45,'',(p,v)=>{ p._op=v; p._paint(); }),
     slider('Center X %',0,100,1,50,'%',(p,v)=>{ p._cx=v; p._paint(); }),
     slider('Center Y %',0,100,1,50,'%',(p,v)=>{ p._cy=v; p._paint(); }),
-    slider('Dot px',1,8,1,2,'px',(p,v)=>{ p._dot=v; p._paint(); }),
-    slider('Gap px',6,30,1,10,'px',(p,v)=>{ p._gap=v; p._paint(); }),
-    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(26,.22)
+    slider('Dot px',1,8,1,3,'px',(p,v)=>{ p._dot=v; p._paint(); }),
+    slider('Gap px',6,30,1,14,'px',(p,v)=>{ p._gap=v; p._paint(); }),
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(28,.24)
   ],
   buildCSS(p){
     return buildOverlayCSS(p, 'after', (p) => {
@@ -538,22 +669,22 @@ CARDS.push({
 CARDS.push({
   id:'scratch', title:'Micro‑scratches', key:'repeating linear · opacity',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,10,120);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.14)'; setBlurSat(p,13,135);
     p._bw=1; p._ba=.14; p.style.border='1px solid rgba(255,255,255,.14)';
     const fx=el('div'); fx.className='scratchFx'; p.appendChild(fx);
     function paint(){ Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
       background:`repeating-linear-gradient(${p._ang}deg, rgba(255,255,255,.5), rgba(255,255,255,.5) ${p._line}px, transparent ${p._line}px, transparent ${p._gap}px)`
     }); }
-    p._ang=20;p._line=1;p._gap=6;p._op=.35; p._paint=paint; paint();
+    p._ang=18;p._line=1;p._gap=10;p._op=.45; p._paint=paint; paint();
   },
   sliders:[
-    bgAlphaSlider(.14), ...baseBlurSat(10,120),
-    slider('Scratch α',0,1,.01,.35,'',(p,v)=>{ p._op=v; p._paint(); }),
-    slider('Angle °',0,180,1,20,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
+    bgAlphaSlider(.14), ...baseBlurSat(13,135),
+    slider('Scratch α',0,1,.01,.45,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Angle °',0,180,1,18,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
     slider('Line px',1,4,1,1,'px',(p,v)=>{ p._line=v; p._paint(); }),
-    slider('Gap px',4,20,1,6,'px',(p,v)=>{ p._gap=v; p._paint(); }),
-    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(26,.22)
+    slider('Gap px',4,20,1,10,'px',(p,v)=>{ p._gap=v; p._paint(); }),
+    borderWidthSlider(1), borderAlphaSlider(.14), ...outerShadowSliders(28,.24)
   ],
   buildCSS(p){
     return buildOverlayCSS(p, 'after', (p) => {
@@ -571,28 +702,33 @@ CARDS.push({
   }
 });
 
-/* === 15 Iridescent Film === */
+/* === 15 Caustic Glass === */
 CARDS.push({
-  id:'film', title:'Iridescent Film', key:'linear overlay',
+  id:'caustic', title:'Caustic Glass', key:'radial & conic overlay',
   setup(p){
-    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,12,120);
-    p._bw=1; p._ba=.10; p.style.border='1px solid rgba(255,255,255,.10)';
-    const fx=el('div'); fx.className='filmFx'; p.appendChild(fx);
+    p._bgcol='13,14,35'; p.style.backgroundColor='rgba(13,14,35,0.12)'; setBlurSat(p,14,150);
+    p._bw=1; p._ba=.12; p.style.border='1px solid rgba(255,255,255,.12)';
+    const fx=el('div'); fx.className='causticFx'; p.appendChild(fx);
     function paint(){ Object.assign(fx.style,{
       position:'absolute',inset:'0',pointerEvents:'none',borderRadius:'inherit',opacity:String(p._op),
-      background:`linear-gradient(${p._ang}deg, rgba(255,0,153,.25), rgba(0,255,204,.25), rgba(0,128,255,.25))`
+      background:`radial-gradient(circle at ${p._cx}% ${p._cy}%, rgba(255,255,255,${p._lightA}), rgba(255,255,255,0) ${p._lightR}%), conic-gradient(from ${p._ang}deg at 50% 50%, rgba(0,255,255,.15), rgba(255,0,255,.15), rgba(0,255,255,.15))`
     }); }
-    p._ang=130;p._op=.55; p._paint=paint; paint();
+    p._cx=50; p._cy=50; p._lightA=.3; p._lightR=40; p._ang=0; p._op=.5; p._paint=paint; paint();
+    p._oblur=24; p._oalpha=.18; rebuildShadow(p);
   },
   sliders:[
-    bgAlphaSlider(.12), ...baseBlurSat(12,120),
-    slider('Overlay α',0,1,.01,.55,'',(p,v)=>{ p._op=v; p._paint(); }),
-    slider('Angle °',0,360,1,130,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
-    borderWidthSlider(1), borderAlphaSlider(.10), ...outerShadowSliders(28,.22)
+    bgAlphaSlider(.12), ...baseBlurSat(14,150),
+    slider('Caustic α',0,1,.01,.5,'',(p,v)=>{ p._op=v; p._paint(); }),
+    slider('Light α',0,.6,.01,.3,'',(p,v)=>{ p._lightA=v; p._paint(); }),
+    slider('Light radius %',20,80,1,40,'%',(p,v)=>{ p._lightR=v; p._paint(); }),
+    slider('Angle °',0,360,1,0,'deg',(p,v)=>{ p._ang=v; p._paint(); }),
+    slider('Center X %',0,100,1,50,'%',(p,v)=>{ p._cx=v; p._paint(); }),
+    slider('Center Y %',0,100,1,50,'%',(p,v)=>{ p._cy=v; p._paint(); }),
+    borderWidthSlider(1), borderAlphaSlider(.12), ...outerShadowSliders(24,.18)
   ],
   buildCSS(p){
     return buildOverlayCSS(p, 'after', (p) => {
-      const s = getComputedStyle(p.querySelector('.filmFx'));
+      const s = getComputedStyle(p.querySelector('.causticFx'));
       return [
         'content: ""',
         'position: absolute',
@@ -625,7 +761,7 @@ function makeCard(def){
       const row = el('div','ctl');
       const lab = el('label'); lab.textContent = s.label;
       const rng = el('input'); rng.type='range'; rng.min=s.min; rng.max=s.max; rng.step=s.step; rng.value=s.value;
-      const read = el('div'); read.style.fontSize='12px'; read.style.color='var(--muted)';
+      const read = el('div'); read.style.fontSize='10px'; read.style.color='var(--muted)';
       read.textContent = s.unit ? `${s.value}${s.unit}` : `${s.value}`;
       rng.addEventListener('input', () => {
         const v = (s.step%1===0)? parseInt(rng.value,10): parseFloat(rng.value);


### PR DESCRIPTION
## Summary
- scale down interface fonts and slider controls for denser layout
- replace Bright Glass with resource-inspired Switcher Panel style
- swap Iridescent Film for Caustic Glass overlay from cursor sample

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc599aa48832e978f7518e7844bd7